### PR TITLE
Minimized use of unsafe and a bit of changes to the api

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,19 +4,16 @@
 // Connection functions
 //
 
-use std::cell::Cell;
-use std::ffi::CString;
-use std::mem;
-use std::os::raw::c_void;
+use std::cell::{Cell, RefCell};
 use std::ptr;
-use std::result::Result;
 
-use super::error::FbError;
+use super::error::{FbError, Status};
 use super::ibase;
 use super::transaction::Transaction;
 
 pub struct Connection {
-    pub handle: Cell<ibase::isc_db_handle>,
+    pub(crate) handle: Cell<ibase::isc_db_handle>,
+    pub(crate) status: RefCell<Status>,
 }
 
 impl Connection {
@@ -28,7 +25,8 @@ impl Connection {
         user: String,
         pass: String,
     ) -> Result<Connection, FbError> {
-        let handle = Cell::new(0 as u32);
+        let handle = Cell::new(0);
+        let status: RefCell<Status> = Default::default();
 
         let dpb = {
             let mut dpb: Vec<u8> = Vec::with_capacity(64);
@@ -52,11 +50,9 @@ impl Connection {
 
         let conn_string = format!("{}/{}:{}", host, port, db_name);
 
-        let mut status: ibase::ISC_STATUS_ARRAY = [0; 20];
-
         unsafe {
             if ibase::isc_attach_database(
-                &mut status,
+                status.borrow_mut().as_mut_ptr(),
                 conn_string.len() as i16,
                 conn_string.as_ptr() as *const i8,
                 handle.as_ptr(),
@@ -64,53 +60,50 @@ impl Connection {
                 dpb.as_ptr() as *const i8,
             ) != 0
             {
-                return Err(FbError::from_status(status.as_mut_ptr() as _));
+                return Err(status.borrow().as_error());
             }
         }
 
         // Assert that the handle is valid
         debug_assert_ne!(handle.get(), 0);
 
-        Ok(Connection { handle })
+        Ok(Connection { handle, status })
     }
 
     /// Open a new connection to the local database
     pub fn open_local(db_name: String) -> Result<Connection, FbError> {
-        let handle = Cell::new(0 as u32);
+        let handle = Cell::new(0);
+        let status: RefCell<Status> = Default::default();
 
         unsafe {
-            let c_db_name = match CString::new(db_name) {
-                Ok(c) => c.into_raw(),
-                Err(e) => {
-                    return Err(FbError {
-                        code: -1,
-                        msg: e.to_string(),
-                    })
-                }
-            };
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            let handle_ptr = handle.as_ptr();
-            if ibase::isc_attach_database(status, 0, c_db_name, handle_ptr, 0, ptr::null()) != 0 {
-                return Err(FbError::from_status(status));
+            if ibase::isc_attach_database(
+                status.borrow_mut().as_mut_ptr(),
+                db_name.len() as i16,
+                db_name.as_ptr() as *const i8,
+                handle.as_ptr(),
+                0,
+                ptr::null(),
+            ) != 0
+            {
+                return Err(status.borrow().as_error());
             }
-
-            libc::free(status as *mut c_void);
         }
 
-        Ok(Connection { handle })
+        // Assert that the handle is valid
+        debug_assert_ne!(handle.get(), 0);
+
+        Ok(Connection { handle, status })
     }
 
     /// Create a new local database
     pub fn create_local(db_name: String) -> Result<(), FbError> {
         let local = Connection {
-            handle: Cell::new(0 as u32),
+            handle: Cell::new(0),
+            status: Default::default(),
         };
 
         let local_tr = Transaction {
-            handle: Cell::new(0 as u32),
+            handle: Cell::new(0),
             conn: &local,
         };
 
@@ -120,22 +113,18 @@ impl Connection {
             return Err(e);
         }
 
+        drop(local_tr);
         local.close()
     }
 
     /// Drop the current database
     pub fn drop_database(self) -> Result<(), FbError> {
         unsafe {
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-
-            let handle_ptr = self.handle.as_ptr();
-            if ibase::isc_drop_database(status, handle_ptr) != 0 {
-                return Err(FbError::from_status(status));
+            if ibase::isc_drop_database(self.status.borrow_mut().as_mut_ptr(), self.handle.as_ptr())
+                != 0
+            {
+                return Err(self.status.borrow().as_error());
             }
-
-            libc::free(status as *mut c_void);
         }
 
         Ok(())
@@ -155,23 +144,40 @@ impl Connection {
     /// Close the current connection
     pub fn close(self) -> Result<(), FbError> {
         unsafe {
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-
-            let handle_ptr = self.handle.as_ptr();
-            if ibase::isc_detach_database(status, handle_ptr) != 0 {
-                return Err(FbError::from_status(status));
+            if ibase::isc_detach_database(
+                self.status.borrow_mut().as_mut_ptr(),
+                self.handle.as_ptr(),
+            ) != 0
+            {
+                return Err(self.status.borrow().as_error());
             }
-
-            libc::free(status as *mut c_void);
         }
+
+        // Assert that the handle is invalid
+        debug_assert_eq!(self.handle.get(), 0);
 
         Ok(())
     }
 
     pub fn start_transaction(&self) -> Result<Transaction, FbError> {
         Transaction::start_transaction(self)
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Close the connection, if the handle is valid
+        if self.handle.get() != 0 {
+            unsafe {
+                ibase::isc_detach_database(
+                    self.status.borrow_mut().as_mut_ptr(),
+                    self.handle.as_ptr(),
+                );
+            }
+        }
+
+        // Assert that the handle is invalid
+        debug_assert_eq!(self.handle.get(), 0);
     }
 }
 

--- a/src/ibase.rs
+++ b/src/ibase.rs
@@ -2445,7 +2445,7 @@ pub type PARAMDSC = paramdsc;
 #[derive(Debug, Copy, Clone)]
 pub struct paramvary {
     pub vary_length: ISC_USHORT,
-    pub vary_string: [ISC_UCHAR; 32usize],
+    pub vary_string: [ISC_UCHAR; 1usize],
 }
 pub type PARAMVARY = paramvary;
 #[repr(C)]
@@ -2474,11 +2474,11 @@ pub struct XSQLDA {
     pub sqldabc: ISC_LONG,
     pub sqln: ISC_SHORT,
     pub sqld: ISC_SHORT,
-    pub sqlvar: [XSQLVAR; 32usize],
+    pub sqlvar: [XSQLVAR; 1usize],
 }
 extern "C" {
     pub fn isc_attach_database(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: ::std::os::raw::c_short,
         arg3: *const ISC_SCHAR,
         arg4: *mut isc_db_handle,
@@ -2611,16 +2611,10 @@ extern "C" {
     pub fn isc_close_blob(arg1: *mut ISC_STATUS, arg2: *mut isc_blob_handle) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_commit_retaining(
-        arg1: *mut ISC_STATUS_ARRAY,
-        arg2: *mut isc_tr_handle,
-    ) -> ISC_STATUS;
+    pub fn isc_commit_retaining(arg1: *mut ISC_STATUS, arg2: *mut isc_tr_handle) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_commit_transaction(
-        arg1: *mut ISC_STATUS_ARRAY,
-        arg2: *mut isc_tr_handle,
-    ) -> ISC_STATUS;
+    pub fn isc_commit_transaction(arg1: *mut ISC_STATUS, arg2: *mut isc_tr_handle) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_create_blob(
@@ -2676,29 +2670,28 @@ extern "C" {
     pub fn isc_decode_timestamp(arg1: *const ISC_TIMESTAMP, arg2: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    pub fn isc_detach_database(arg1: *mut ISC_STATUS_ARRAY, arg2: *mut isc_db_handle)
-        -> ISC_STATUS;
+    pub fn isc_detach_database(arg1: *mut ISC_STATUS, arg2: *mut isc_db_handle) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_drop_database(arg1: *mut ISC_STATUS_ARRAY, arg2: *mut isc_db_handle) -> ISC_STATUS;
+    pub fn isc_drop_database(arg1: *mut ISC_STATUS, arg2: *mut isc_db_handle) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_dsql_allocate_statement(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_db_handle,
         arg3: *mut isc_stmt_handle,
     ) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_dsql_alloc_statement2(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_db_handle,
         arg3: *mut isc_stmt_handle,
     ) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_dsql_describe(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_stmt_handle,
         arg3: ::std::os::raw::c_ushort,
         arg4: *mut XSQLDA,
@@ -2706,7 +2699,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_describe_bind(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_stmt_handle,
         arg3: ::std::os::raw::c_ushort,
         arg4: *mut XSQLDA,
@@ -2726,7 +2719,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_execute(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_tr_handle,
         arg3: *mut isc_stmt_handle,
         arg4: ::std::os::raw::c_ushort,
@@ -2745,7 +2738,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_execute_immediate(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_db_handle,
         arg3: *mut isc_tr_handle,
         arg4: ::std::os::raw::c_ushort,
@@ -2756,7 +2749,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_fetch(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_stmt_handle,
         arg3: ::std::os::raw::c_ushort,
         arg4: *const XSQLDA,
@@ -2767,7 +2760,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_free_statement(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_stmt_handle,
         arg3: ::std::os::raw::c_ushort,
     ) -> ISC_STATUS;
@@ -2782,7 +2775,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_dsql_prepare(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_tr_handle,
         arg3: *mut isc_stmt_handle,
         arg4: ::std::os::raw::c_ushort,
@@ -2894,13 +2887,13 @@ extern "C" {
     ) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_interprete(arg1: *mut ISC_SCHAR, arg2: *mut *mut ISC_STATUS_ARRAY) -> ISC_LONG;
+    pub fn isc_interprete(arg1: *mut ISC_SCHAR, arg2: *mut *mut ISC_STATUS) -> ISC_LONG;
 }
 extern "C" {
     pub fn fb_interpret(
         arg1: *mut ISC_SCHAR,
         arg2: ::std::os::raw::c_uint,
-        arg3: *mut *mut ISC_STATUS_ARRAY,
+        arg3: *mut *const ISC_STATUS,
     ) -> ISC_LONG;
 }
 extern "C" {
@@ -2971,16 +2964,10 @@ extern "C" {
     ) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_rollback_retaining(
-        arg1: *mut ISC_STATUS_ARRAY,
-        arg2: *mut isc_tr_handle,
-    ) -> ISC_STATUS;
+    pub fn isc_rollback_retaining(arg1: *mut ISC_STATUS, arg2: *mut isc_tr_handle) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_rollback_transaction(
-        arg1: *mut ISC_STATUS_ARRAY,
-        arg2: *mut isc_tr_handle,
-    ) -> ISC_STATUS;
+    pub fn isc_rollback_transaction(arg1: *mut ISC_STATUS, arg2: *mut isc_tr_handle) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_start_multiple(
@@ -2992,7 +2979,7 @@ extern "C" {
 }
 extern "C" {
     pub fn isc_start_transaction(
-        arg1: *mut ISC_STATUS_ARRAY,
+        arg1: *mut ISC_STATUS,
         arg2: *mut isc_tr_handle,
         arg3: ::std::os::raw::c_short,
         ...
@@ -3003,7 +2990,7 @@ extern "C" {
         -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_sqlcode(arg1: *const ISC_STATUS_ARRAY) -> ISC_LONG;
+    pub fn isc_sqlcode(arg1: *const ISC_STATUS) -> ISC_LONG;
 }
 extern "C" {
     pub fn isc_sqlcode_s(arg1: *const ISC_STATUS, arg2: *mut ISC_ULONG);
@@ -3102,10 +3089,7 @@ extern "C" {
     ) -> ISC_STATUS;
 }
 extern "C" {
-    pub fn isc_prepare_transaction(
-        arg1: *mut ISC_STATUS_ARRAY,
-        arg2: *mut isc_tr_handle,
-    ) -> ISC_STATUS;
+    pub fn isc_prepare_transaction(arg1: *mut ISC_STATUS, arg2: *mut isc_tr_handle) -> ISC_STATUS;
 }
 extern "C" {
     pub fn isc_receive(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@ extern crate libc;
 
 mod connection;
 mod error;
+#[allow(clippy::redundant_static_lifetimes)]
 mod ibase;
 mod row;
 mod statement;
 mod transaction;
+mod xsqlda;
 
 pub use self::connection::Connection;
 pub use self::error::FbError;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -4,12 +4,8 @@
 // Preparation and execution of statements
 //
 
-use std::cell::Cell;
-use std::ffi::CString;
-use std::mem;
 use std::os::raw::c_char;
 use std::os::raw::c_short;
-use std::os::raw::c_void;
 use std::ptr;
 use std::result::Result;
 
@@ -17,83 +13,64 @@ use super::error::FbError;
 use super::ibase;
 use super::row::Row;
 use super::transaction::Transaction;
+use super::xsqlda::XSqlDa;
 
-pub struct Statement<'a> {
-    handle: Cell<ibase::isc_stmt_handle>,
-    xsqlda: Cell<*mut ibase::XSQLDA>,
-    tr: &'a Transaction<'a>,
+pub struct Statement<'c, 't> {
+    pub(crate) handle: ibase::isc_stmt_handle,
+    pub(crate) xsqlda: XSqlDa,
+    pub(crate) tr: &'t Transaction<'c>,
 }
 
-impl<'a> Statement<'a> {
+impl<'c, 't> Statement<'c, 't> {
     /// Prepare the statement that will be executed
-    pub fn prepare(tr: &'a Transaction, sql: String) -> Result<Statement<'a>, FbError> {
-        let handle = Cell::new(0 as u32);
+    pub fn prepare(tr: &'t Transaction<'c>, sql: String) -> Result<Statement<'c, 't>, FbError> {
+        let mut handle = 0;
+        let status = &tr.conn.status;
 
-        let xsqlda = Cell::new(unsafe { libc::malloc(xsqlda_length(1)) as *mut ibase::XSQLDA });
+        let mut xsqlda = XSqlDa::new(1);
 
         unsafe {
-            let conn_handle_ptr = tr.conn.handle.as_ptr();
-            let handle_ptr = handle.as_ptr();
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            if ibase::isc_dsql_allocate_statement(status, conn_handle_ptr, handle_ptr) != 0 {
-                return Err(FbError::from_status(status));
-            }
-
-            libc::free(status as *mut c_void);
-
-            let xsqlda_ptr = *xsqlda.as_ptr();
-            (*xsqlda_ptr).version = 1;
-
-            let c_sql = match CString::new(sql) {
-                Ok(c) => c.into_raw(),
-                Err(e) => {
-                    return Err(FbError {
-                        code: -1,
-                        msg: e.to_string(),
-                    })
-                }
-            };
-            let tr_handle_ptr = tr.handle.as_ptr();
-            let handle_ptr = handle.as_ptr();
-            let xsqlda_ptr = *xsqlda.as_ptr();
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            if ibase::isc_dsql_prepare(status, tr_handle_ptr, handle_ptr, 0, c_sql, 1, xsqlda_ptr)
-                != 0
+            if ibase::isc_dsql_allocate_statement(
+                status.borrow_mut().as_mut_ptr(),
+                tr.conn.handle.as_ptr(),
+                &mut handle,
+            ) != 0
             {
-                return Err(FbError::from_status(status));
+                return Err(status.borrow().as_error());
             }
 
-            libc::free(status as *mut c_void);
+            if ibase::isc_dsql_prepare(
+                status.borrow_mut().as_mut_ptr(),
+                tr.handle.as_ptr(),
+                &mut handle,
+                sql.len() as u16,
+                sql.as_ptr() as *const i8,
+                1, // TODO: Add a way to select the dialect (1, 2 or 3)
+                &mut *xsqlda,
+            ) != 0
+            {
+                return Err(status.borrow().as_error());
+            }
         }
 
-        Ok(Statement {
-            handle: handle,
-            xsqlda: xsqlda,
-            tr: tr,
-        })
+        Ok(Statement { handle, xsqlda, tr })
     }
 
     /// Execute the current statement without parameters
-    pub fn execute_simple(&self) -> Result<(), FbError> {
+    pub fn execute_simple(&mut self) -> Result<(), FbError> {
+        let status = &self.tr.conn.status;
+
         unsafe {
-            let handle_ptr = self.handle.as_ptr();
-            let tr_handle_ptr = self.tr.handle.as_ptr();
-            let xsqlda_ptr = *self.xsqlda.as_ptr();
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            if ibase::isc_dsql_execute(status, tr_handle_ptr, handle_ptr, 1, xsqlda_ptr) != 0 {
-                return Err(FbError::from_status(status));
+            if ibase::isc_dsql_execute(
+                status.borrow_mut().as_mut_ptr(),
+                self.tr.handle.as_ptr(),
+                &mut self.handle,
+                1,
+                &*self.xsqlda,
+            ) != 0
+            {
+                return Err(status.borrow().as_error());
             }
-
-            libc::free(status as *mut c_void);
         }
 
         Ok(())
@@ -101,144 +78,136 @@ impl<'a> Statement<'a> {
 
     /// Execute the current statement without parameters
     /// and returns the lines founds
-    pub fn query_simple(self) -> Result<StatementFetch, FbError> {
-        unsafe {
-            let handle_ptr = self.handle.as_ptr();
-            let mut xsqlda_ptr = *self.xsqlda.as_ptr();
+    pub fn query_simple<'s>(&'s mut self) -> Result<StatementFetch<'c, 't, 's>, FbError> {
+        let status = &self.tr.conn.status;
+        let row_count = self.xsqlda.sqld;
 
-            // Need more XSQLVARs
-            if (*xsqlda_ptr).sqld > (*xsqlda_ptr).sqln {
-                let num_cols = (*xsqlda_ptr).sqld;
-                libc::free(xsqlda_ptr as *mut c_void);
-
-                self.xsqlda
-                    .replace(libc::malloc(xsqlda_length(num_cols)) as *mut ibase::XSQLDA);
-                xsqlda_ptr = *self.xsqlda.as_ptr();
-
-                (*xsqlda_ptr).version = 1;
-                (*xsqlda_ptr).sqln = num_cols;
-
-                let status: *mut ibase::ISC_STATUS_ARRAY =
-                    libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                        as *mut ibase::ISC_STATUS_ARRAY;
-                if ibase::isc_dsql_describe(status, handle_ptr, 1, xsqlda_ptr) != 0 {
-                    return Err(FbError::from_status(status));
-                }
-                libc::free(status as *mut c_void);
-            }
-
-            let tr_handle_ptr = self.tr.handle.as_ptr();
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            if ibase::isc_dsql_describe(status, handle_ptr, 1, xsqlda_ptr) != 0 {
-                return Err(FbError::from_status(status));
-            }
-            libc::free(status as *mut c_void);
-
-            for col in 0..(*xsqlda_ptr).sqld {
-                let mut xcol = (*xsqlda_ptr).sqlvar[col as usize];
-
-                xcol.sqldata = libc::malloc(xcol.sqllen as usize) as *mut c_char;
-                xcol.sqlind = libc::malloc(1) as *mut c_short;
-
-                (*xsqlda_ptr).sqlvar[col as usize] = xcol;
-            }
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            if ibase::isc_dsql_execute(status, tr_handle_ptr, handle_ptr, 1, xsqlda_ptr) != 0 {
-                return Err(FbError::from_status(status));
-            }
-            libc::free(status as *mut c_void);
+        // Need more XSQLVARs
+        if row_count > self.xsqlda.sqln {
+            self.xsqlda = XSqlDa::new(row_count);
         }
 
-        Ok(StatementFetch {
-            handle: self.handle,
-            xsqlda: self.xsqlda,
-        })
+        unsafe {
+            if ibase::isc_dsql_describe(
+                status.borrow_mut().as_mut_ptr(),
+                &mut self.handle,
+                1,
+                &mut *self.xsqlda,
+            ) != 0
+            {
+                return Err(status.borrow().as_error());
+            }
+
+            for col in 0..self.xsqlda.sqln {
+                let mut xcol = self.xsqlda.get_xsqlvar_mut(col as usize).unwrap();
+
+                // + 2 because varchars need two more bytes to store the size
+                // TODO: Data never dealocated
+                xcol.sqldata = libc::malloc(xcol.sqllen as usize + 2) as *mut c_char;
+                xcol.sqlind = libc::malloc(1) as *mut c_short;
+            }
+
+            if ibase::isc_dsql_execute(
+                status.borrow_mut().as_mut_ptr(),
+                self.tr.handle.as_ptr(),
+                &mut self.handle,
+                1,
+                &*self.xsqlda,
+            ) != 0
+            {
+                return Err(status.borrow().as_error());
+            }
+        }
+
+        Ok(StatementFetch { stmt: self })
     }
 
     /// Execute the statement without returning any row
     pub fn execute_immediate(tr: &Transaction, sql: String) -> Result<(), FbError> {
+        let status = &tr.conn.status;
+
         unsafe {
-            let handle_ptr = tr.handle.as_ptr();
-            let conn_handle_ptr = tr.conn.handle.as_ptr();
-
-            let c_sql = match CString::new(sql) {
-                Ok(c) => c.into_raw(),
-                Err(e) => {
-                    return Err(FbError {
-                        code: -1,
-                        msg: e.to_string(),
-                    })
-                }
-            };
-
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
             if ibase::isc_dsql_execute_immediate(
-                status,
-                conn_handle_ptr,
-                handle_ptr,
-                0,
-                c_sql,
+                status.borrow_mut().as_mut_ptr(),
+                tr.conn.handle.as_ptr(),
+                tr.handle.as_ptr(),
+                sql.len() as u16,
+                sql.as_ptr() as *const i8,
                 1,
                 ptr::null(),
             ) != 0
             {
-                return Err(FbError::from_status(status));
+                return Err(status.borrow().as_error());
             }
-
-            libc::free(status as *mut c_void);
         }
 
         Ok(())
     }
 }
 
-pub struct StatementFetch {
-    handle: Cell<ibase::isc_stmt_handle>,
-    pub xsqlda: Cell<*mut ibase::XSQLDA>,
+impl<'c, 't> Drop for Statement<'c, 't> {
+    fn drop(&mut self) {
+        let status = &self.tr.conn.status;
+
+        // Close the statement
+        unsafe {
+            ibase::isc_dsql_free_statement(
+                status.borrow_mut().as_mut_ptr(),
+                &mut self.handle,
+                ibase::DSQL_drop as u16,
+            )
+        };
+
+        // Assert that the handle is invalid
+        debug_assert_eq!(self.handle, 0);
+    }
+}
+/// Cursor to fetch the results of a statement
+pub struct StatementFetch<'c, 't, 's> {
+    pub(crate) stmt: &'s mut Statement<'c, 't>,
 }
 
-impl StatementFetch {
+impl<'c, 't, 's> StatementFetch<'c, 't, 's> {
     /// Fetch for the next row
-    pub fn fetch(&mut self) -> Result<Option<Row>, FbError> {
-        unsafe {
-            let handle_ptr = self.handle.as_ptr();
-            let xsqlda_ptr = *self.xsqlda.as_ptr();
+    pub fn fetch<'sf>(&'sf mut self) -> Result<Option<Row<'c, 't, 's, 'sf>>, FbError> {
+        let status = &self.stmt.tr.conn.status;
 
-            let status: *mut ibase::ISC_STATUS_ARRAY =
-                libc::malloc(mem::size_of::<ibase::ISC_STATUS_ARRAY>())
-                    as *mut ibase::ISC_STATUS_ARRAY;
-            let result_fetch = ibase::isc_dsql_fetch(status, handle_ptr, 1, xsqlda_ptr);
-
-            // 100 indicates that no more rows: http://docwiki.embarcadero.com/InterBase/2020/en/Isc_dsql_fetch()
-            if result_fetch == 100 {
-                return Ok(None);
-            }
-
-            if result_fetch != 0 {
-                return Err(FbError::from_status(status));
-            }
-
-            libc::free(status as *mut c_void);
-
-            let row = Row { stmt_ft: self };
-
-            Ok(Some(row))
+        let result_fetch = unsafe {
+            ibase::isc_dsql_fetch(
+                status.borrow_mut().as_mut_ptr(),
+                &mut self.stmt.handle,
+                1,
+                &*self.stmt.xsqlda,
+            )
+        };
+        // 100 indicates that no more rows: http://docwiki.embarcadero.com/InterBase/2020/en/Isc_dsql_fetch()
+        if result_fetch == 100 {
+            return Ok(None);
         }
+
+        if result_fetch != 0 {
+            return Err(status.borrow().as_error());
+        }
+
+        let row = Row { stmt_ft: self };
+
+        Ok(Some(row))
     }
 }
 
-/// Implementation of XSQLDA_LENGTH macro
-fn xsqlda_length(size: i16) -> usize {
-    let n = (size - 1).max(0) as usize;
+impl<'c, 't, 's> Drop for StatementFetch<'c, 't, 's> {
+    fn drop(&mut self) {
+        let status = &self.stmt.tr.conn.status;
 
-    std::mem::size_of::<ibase::XSQLDA>() + (std::mem::size_of::<ibase::XSQLVAR>() * n)
+        unsafe {
+            // Close the cursor
+            ibase::isc_dsql_free_statement(
+                status.borrow_mut().as_mut_ptr(),
+                &mut self.stmt.handle,
+                ibase::DSQL_close as u16,
+            )
+        };
+    }
 }
 
 #[cfg(test)]
@@ -266,7 +235,7 @@ mod test {
             .start_transaction()
             .expect("Error on start the transaction");
 
-        let stmt = tr
+        let mut stmt = tr
             .prepare("select id, name from product".to_string())
             .expect("Error on prepare the select");
 
@@ -322,6 +291,10 @@ mod test {
             "The 4° row dont exists, then should return a None"
         ); // null value
 
+        drop(rows);
+
+        drop(stmt);
+
         tr.rollback().expect("Error on rollback the transaction");
 
         conn.close().expect("error on close the connection");
@@ -335,11 +308,13 @@ mod test {
             .start_transaction()
             .expect("Error on start the transaction");
 
-        let stmt = tr
+        let mut stmt = tr
             .prepare("insert into product (id, name) values (1, 'apple')".to_string())
             .expect("Error on prepare");
 
         stmt.execute_simple().expect("Error on execute");
+
+        drop(stmt);
 
         tr.commit().expect("Error on commit the transaction");
 

--- a/src/xsqlda.rs
+++ b/src/xsqlda.rs
@@ -1,0 +1,84 @@
+use std::{
+    alloc,
+    ops::{Deref, DerefMut},
+    ptr,
+};
+
+use super::ibase;
+
+pub struct XSqlDa {
+    ptr: ptr::NonNull<ibase::XSQLDA>,
+    len: i16,
+}
+
+impl XSqlDa {
+    /// Allocates a new XSQLDA of length `len`
+    pub fn new(len: i16) -> Self {
+        #[allow(clippy::cast_ptr_alignment)]
+        let ptr = unsafe { alloc::alloc_zeroed(xsqlda_layout(len)) } as *mut ibase::XSQLDA;
+
+        let mut ptr = if let Some(ptr) = ptr::NonNull::new(ptr) {
+            ptr
+        } else {
+            alloc::handle_alloc_error(xsqlda_layout(len))
+        };
+
+        unsafe {
+            ptr.as_mut().version = ibase::SQLDA_VERSION1 as i16;
+            ptr.as_mut().sqln = len;
+        }
+
+        Self { ptr, len }
+    }
+
+    /// Returns a reference to a XSQLVAR
+    pub fn get_xsqlvar(&self, col: usize) -> Option<&ibase::XSQLVAR> {
+        if col < self.sqld as usize {
+            let xsqlvar = unsafe { self.ptr.as_ref().sqlvar.get_unchecked(col as usize) };
+
+            Some(xsqlvar)
+        } else {
+            None
+        }
+    }
+
+    /// Returns a mutable reference to a XSQLVAR
+    pub fn get_xsqlvar_mut(&mut self, col: usize) -> Option<&mut ibase::XSQLVAR> {
+        if col < self.sqld as usize {
+            let xsqlvar = unsafe { self.ptr.as_mut().sqlvar.get_unchecked_mut(col as usize) };
+
+            Some(xsqlvar)
+        } else {
+            None
+        }
+    }
+}
+
+impl Deref for XSqlDa {
+    type Target = ibase::XSQLDA;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl DerefMut for XSqlDa {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl Drop for XSqlDa {
+    fn drop(&mut self) {
+        unsafe { alloc::dealloc(self.ptr.as_ptr() as *mut u8, xsqlda_layout(self.len)) }
+    }
+}
+
+/// Calculates the memory layout (size and alignment) for a xsqlda
+fn xsqlda_layout(len: i16) -> alloc::Layout {
+    let (xsqlda_layout, _) = alloc::Layout::new::<ibase::XSQLDA>()
+        .extend(alloc::Layout::array::<ibase::XSQLVAR>((len - 1).max(0) as usize).unwrap())
+        .unwrap();
+
+    xsqlda_layout
+}


### PR DESCRIPTION
I've also changed some of the types in the `ibase` module back to the originals generated by bindgen, i think it's better
to not change the autogenerated code to simplify moving to newer versions of the fbclient, and the module
could be autogenerated if we can make static linking work, what do you think?