### PR TITLE
Fixed wrong BIGINT buffering. (Fix #11)

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -304,7 +304,7 @@ fn integer_from_buffer(buffer: &[u8]) -> Result<i64, FbError> {
     }
 
     Ok(i64::from_le_bytes([
-        buffer[0], buffer[1], buffer[2], buffer[3], buffer[0], buffer[1], buffer[2], buffer[3],
+        buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[6], buffer[7],
     ]))
 }
 


### PR DESCRIPTION
Related to https://github.com/fernandobatels/rsfbclient/issues/11.