### PR TITLE
ci: run tests on windows

### DIFF
--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -95,7 +95,6 @@ jobs:
         if: matrix.plataform == 'windows'
         run: |
           choco install firebird -params '/SuperClassic'
-          choco install firebird-odbc
 
       - name: Locating fbclient.lib Dir on Windows
         if: matrix.plataform == 'windows'
@@ -115,12 +114,6 @@ jobs:
               $found = Get-ChildItem -File -Recurse -Path $folder -Include $FileName -ea 0
               Foreach ($source in $found) {
                 echo "Found: $source"
-                # $CurDir = Get-Location
-                # $DestDir = Join-Path -Path $CurDir -ChildPath "target\debug\deps"
-                # $DestFile = Join-Path -Path $DestDir -ChildPath $FileName
-                # New-Item $DestDir -ItemType Directory -ea 0
-                # echo "Copying $source to $DesdtDir"
-                # Copy-Item -Path $source -Destination $DestFile
               }
             }
           }
@@ -157,26 +150,6 @@ jobs:
         run: |
           echo "CREATE DATABASE 'localhost:test.fdb';" | & "C:\Program Files\Firebird\Firebird_3_0\isql.exe" -bail -quiet -z -user SYSDBA -password masterkey
 
-      # - name: Create database test.fdb in fb ${{ matrix.firebird }} on Windows
-      #   if: matrix.plataform == 'windows'
-      #   shell: powershell
-      #   run: |
-      #     function Execute-ODBC-Query{
-      #       param(
-      #         [string]$Query=$(throw 'query is required.'),
-      #         [string]$DSN=$(throw 'DSN is required.')
-      #       )
-      #       $conn = New-Object System.Data.Odbc.OdbcConnection
-      #       $conn.ConnectionString= "DSN=$DSN;"
-      #       $cmd = new-object System.Data.Odbc.OdbcCommand($Query,$conn)
-      #       $conn.open()
-      #       $cmd.ExecuteNonQuery()
-      #       $conn.close()
-      #     }
-      #     # executing on local firebird
-      #     Add-OdbcDsn -Name "odbcfirebird" -DriverName "Firebird/InterBase(r) driver" -DsnType "System" -SetPropertyValue @("DBNAME=security3.fdb", "USER=SYSDBA", "PASSWORD=masterkey")
-      #     Execute-ODBC-Query -Query "create database test.fdb" -DSN "odbcfirebird"
-
       - name: Testing Connection and Query on Linux
         if: matrix.firebird != 'v4' && matrix.plataform == 'linux'
         run: |
@@ -205,6 +178,8 @@ jobs:
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
+        if: matrix.plataform == 'linux'
+        # TODO: #[error]The process 'C:\Rust\.cargo\bin\cargo.exe' failed with exit code 101: error: no such subcommand: `tarpaulin`
         with:
           version: "latest"
           run-types: "AllTargets"
@@ -213,6 +188,7 @@ jobs:
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
+        if: matrix.plataform == 'linux'
         env:
           COVERALLS_FLAG_NAME: run-${{ matrix.firebird }}-${{ matrix.build }}
         with:

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -101,36 +101,47 @@ jobs:
         shell: powershell
         run: |
           # Get-ChildItem -File -Recurse -Path "C:\Program Files\Firebird\Firebird_3_0" -Name
-          $WinSysDir = [Environment]::SystemDirectory
-          $CurDir = Get-Location
-          $DestFile = Join-Path -Path $CurDir -ChildPath "fbclient.lib"
-          $Dirs = @(
-              "${WinSysDir}",
-              "C:\Program Files\Firebird\Firebird_3_0", 
-              "C:\Program Files\Firebird\Firebird_4_0", 
-              "C:\Program Files\Firebird\Firebird_2_5"
-              )
-          $Libs = @( 
-              "fbclient_ms.lib", 
-              "fbclient.lib", 
-              "lib\fbclient_ms.lib", 
-              "lib\fbclient.lib", 
-              "WOW64\lib\fbclient_ms.lib", 
-              "WOW64\lib\fbclient.lib" 
-              )
-          Foreach ($dr in $Dirs) {
-            Foreach ($lb in $Libs) {
-              $Source = Join-Path -Path $dr -ChildPath $lb
-              echo "Searching for $Source"
-              if (Test-Path $Source -PathType Leaf) {
-                echo "Coying $Source to $DestFile"
-                Copy-Item -Path $Source -Destination $DestFile
-                return
+          function Find-Copy() {
+            param (
+                $Files, $FileName
+            )
+            $WinSysDir = [Environment]::SystemDirectory
+            $CurDir = Get-Location
+            $DestDir = Join-Path -Path $CurDir -ChildPath "target\debug\deps"
+            $DestFile = Join-Path -Path $DestDir -ChildPath $FileName
+            $Dirs = @(
+                "${WinSysDir}",
+                "C:\Program Files\Firebird\Firebird_3_0", 
+                "C:\Program Files\Firebird\Firebird_4_0", 
+                "C:\Program Files\Firebird\Firebird_2_5"
+                )
+            $Subs = @(
+                "", 
+                "lib", 
+                "WOW64" 
+                "WOW64\lib" 
+                )
+            Foreach ($prefix in $Dirs) {
+              Foreach ($infix in $Subs) {
+                $folder = Join-Path -Path $prefix -ChildPath $infix
+                Foreach ($suffix in $Files) {
+                  $Source = Join-Path -Path $folder -ChildPath $suffix
+                  echo "Searched for $Source"
+                  if (Test-Path $Source -PathType Leaf) {
+                    echo "Coying $Source to $DestFile"
+                    New-Item $DestDir -ItemType Directory -ea 0
+                    Copy-Item -Path $Source -Destination $DestFile
+                    return
+                  }
+                }
               }
             }
+            echo "File $FileName not copied to $DesdtDir !!!"
           }
-          echo "fbclient.lib not found !!!"
-          return 1
+          $Libs = @( "fbclient_ms.lib", "fbclient.lib" )
+          $Dlls = @( "fbclient.dll" )
+          Find-Copy -Files $Libs -FileName "fbclient.lib"
+          Find-Copy -Files $Dlls -FileName "fbclient.dll"
 
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -91,57 +91,42 @@ jobs:
           firebird_password: "test_password"
           isc_password: "masterkey"
 
-      - name: Setup FirebirdSQL ${{ matrix.firebird }} on  ${{ matrix.os }}
+      - name: Setup FirebirdSQL ${{ matrix.firebird }} on Windows
         if: matrix.plataform == 'windows'
         run: |
           choco install firebird -params '/ClientAndDevTools'
 
-      - name: Copying fbclient.lib to Current Dir on ${{ matrix.os }} 
+      - name: Locating fbclient.lib Dir on Windows
         if: matrix.plataform == 'windows'
         shell: powershell
         run: |
-          # Get-ChildItem -File -Recurse -Path "C:\Program Files\Firebird\Firebird_3_0" -Name
-          function Find-Copy() {
+          function Search-Common-Folders() {
             param (
-                $Files, $FileName
+                [string]$FileName
             )
             $WinSysDir = [Environment]::SystemDirectory
-            $CurDir = Get-Location
-            $DestDir = Join-Path -Path $CurDir -ChildPath "target\debug\deps"
-            $DestFile = Join-Path -Path $DestDir -ChildPath $FileName
-            $Dirs = @(
-                "${WinSysDir}",
+            $CommonDirs = @(
                 "C:\Program Files\Firebird\Firebird_3_0", 
-                "C:\Program Files\Firebird\Firebird_4_0", 
-                "C:\Program Files\Firebird\Firebird_2_5"
+                "C:\Program Files\Firebird", 
+                "C:\Firebird",
+                "${WinSysDir}"
                 )
-            $Subs = @(
-                "", 
-                "lib", 
-                "WOW64" 
-                "WOW64\lib" 
-                )
-            Foreach ($prefix in $Dirs) {
-              Foreach ($infix in $Subs) {
-                $folder = Join-Path -Path $prefix -ChildPath $infix
-                Foreach ($suffix in $Files) {
-                  $Source = Join-Path -Path $folder -ChildPath $suffix
-                  echo "Searched for $Source"
-                  if (Test-Path $Source -PathType Leaf) {
-                    echo "Coying $Source to $DestFile"
-                    New-Item $DestDir -ItemType Directory -ea 0
-                    Copy-Item -Path $Source -Destination $DestFile
-                    return
-                  }
-                }
+            Foreach ($folder in $CommonDirs) {
+              $found = Get-ChildItem -File -Recurse -Path $folder -Include $FileName -ea 0
+              Foreach ($source in $found) {
+                echo "Found: $source"
+                # $CurDir = Get-Location
+                # $DestDir = Join-Path -Path $CurDir -ChildPath "target\debug\deps"
+                # $DestFile = Join-Path -Path $DestDir -ChildPath $FileName
+                # New-Item $DestDir -ItemType Directory -ea 0
+                # echo "Copying $source to $DesdtDir"
+                # Copy-Item -Path $source -Destination $DestFile
               }
             }
-            echo "File $FileName not copied to $DesdtDir !!!"
           }
-          $Libs = @( "fbclient_ms.lib", "fbclient.lib" )
-          $Dlls = @( "fbclient.dll" )
-          Find-Copy -Files $Libs -FileName "fbclient.lib"
-          Find-Copy -Files $Dlls -FileName "fbclient.dll"
+          Search-Common-Folders -FileName "fbclient.dll"
+          Search-Common-Folders -FileName "fbclient.lib"
+          Search-Common-Folders -FileName "fbclient_ms.lib"
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -160,13 +145,13 @@ jobs:
           toolchain: stable
           default: true
 
-      - name: Install cli and development library
+      - name: Install cli and development library on Linux
         if: matrix.plataform == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends firebird3.0-utils firebird-dev
 
-      - name: Testing Connection and Query
+      - name: Testing Connection and Query on Linux
         if: matrix.firebird != 'v4' && matrix.plataform == 'linux'
         run: |
           SQL1='select RDB$CHARACTER_SET_NAME as charset_sysdba from rdb$database;' 
@@ -177,6 +162,13 @@ jobs:
         run: |
           SQL2='select RDB$CHARACTER_SET_NAME as charset_user from rdb$database;' 
           echo $SQL2 | isql-fb -bail -quiet -z -user test_user -password test_password 'localhost:test.fdb'
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -vv --features '${{ matrix.features }}'
+          # Searching for fbclient.lib in rsfbclient-native/build.rs
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Setup FirebirdSQL ${{ matrix.firebird }} on Windows
         if: matrix.plataform == 'windows'
         run: |
-          choco install firebird -params '/ClientAndDevTools'
+          choco install firebird -params '/SuperClassic'
+          choco install firebird-odbc
 
       - name: Locating fbclient.lib Dir on Windows
         if: matrix.plataform == 'windows'
@@ -106,7 +107,6 @@ jobs:
             )
             $WinSysDir = [Environment]::SystemDirectory
             $CommonDirs = @(
-                "C:\Program Files\Firebird\Firebird_3_0", 
                 "C:\Program Files\Firebird", 
                 "C:\Firebird",
                 "${WinSysDir}"
@@ -127,6 +127,7 @@ jobs:
           Search-Common-Folders -FileName "fbclient.dll"
           Search-Common-Folders -FileName "fbclient.lib"
           Search-Common-Folders -FileName "fbclient_ms.lib"
+          Search-Common-Folders -FileName "isql.exe"
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -150,6 +151,31 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends firebird3.0-utils firebird-dev
+
+      - name: Create database test.fdb in fb ${{ matrix.firebird }} on Windows
+        if: matrix.plataform == 'windows'
+        run: |
+          echo "CREATE DATABASE 'localhost:test.fdb';" | & "C:\Program Files\Firebird\Firebird_3_0\isql.exe" -bail -quiet -z -user SYSDBA -password masterkey
+
+      # - name: Create database test.fdb in fb ${{ matrix.firebird }} on Windows
+      #   if: matrix.plataform == 'windows'
+      #   shell: powershell
+      #   run: |
+      #     function Execute-ODBC-Query{
+      #       param(
+      #         [string]$Query=$(throw 'query is required.'),
+      #         [string]$DSN=$(throw 'DSN is required.')
+      #       )
+      #       $conn = New-Object System.Data.Odbc.OdbcConnection
+      #       $conn.ConnectionString= "DSN=$DSN;"
+      #       $cmd = new-object System.Data.Odbc.OdbcCommand($Query,$conn)
+      #       $conn.open()
+      #       $cmd.ExecuteNonQuery()
+      #       $conn.close()
+      #     }
+      #     # executing on local firebird
+      #     Add-OdbcDsn -Name "odbcfirebird" -DriverName "Firebird/InterBase(r) driver" -DsnType "System" -SetPropertyValue @("DBNAME=security3.fdb", "USER=SYSDBA", "PASSWORD=masterkey")
+      #     Execute-ODBC-Query -Query "create database test.fdb" -DSN "odbcfirebird"
 
       - name: Testing Connection and Query on Linux
         if: matrix.firebird != 'v4' && matrix.plataform == 'linux'

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -6,9 +6,8 @@
 #   - https://github.com/actions-rs/cargo       -> https://github.com/marketplace/actions/rust-cargo
 #
 # for simplicity we are checking compilation and testing everything on the Ubuntu environment only.
+#
 # TODO:
-#   - Fix tests for dynamic_loading, embedded
-#   - Run in windows
 #   - Run in arm little-endian architecture
 
 on: [push, pull_request]
@@ -53,26 +52,37 @@ jobs:
 
   testing:
     name: testing
-    needs: linting
-    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
+        os: [ "ubuntu-20.04", "windows-latest" ]
         firebird: [v3, v2, v4]
         build: [linking, dynamic_loading]
+        exclude:
+          - os: "windows-latest" 
+            firebird: v2
+          - os: "windows-latest" 
+            firebird: v4
         include:
-        - firebird: v2
-          image: "2.5-ss"
-        - firebird: v3
-          image: "3.0"
-        - firebird: v4
-          image: "4.0"
-        - build: linking
-          features: linking date_time pool
-        - build: dynamic_loading
-          features: dynamic_loading date_time pool
+          - os: "ubuntu-20.04"
+            plataform: linux
+          - os: "windows-latest"
+            plataform: windows
+          - firebird: v2
+            image: "2.5-ss"
+          - firebird: v3
+            image: "3.0"
+          - firebird: v4
+            image: "4.0"
+          - build: linking
+            features: linking date_time pool
+          - build: dynamic_loading
+            features: dynamic_loading date_time pool
+    runs-on: "${{ matrix.os }}"
+    needs: linting
     steps:
-      - name: Setup FirebirdSQL ${{ matrix.firebird }} with image  ${{ matrix.image }} for tests
+      - name: Setup FirebirdSQL ${{ matrix.firebird }} with image  ${{ matrix.image }} on docker
+        if: matrix.plataform == 'linux'
         uses: juarezr/firebirdsql-github-action@v1.0.0
         with:
           version: "${{ matrix.image }}"
@@ -80,6 +90,47 @@ jobs:
           firebird_user: "test_user"
           firebird_password: "test_password"
           isc_password: "masterkey"
+
+      - name: Setup FirebirdSQL ${{ matrix.firebird }} on  ${{ matrix.os }}
+        if: matrix.plataform == 'windows'
+        run: |
+          choco install firebird -params '/ClientAndDevTools'
+
+      - name: Copying fbclient.lib to Current Dir on ${{ matrix.os }} 
+        if: matrix.plataform == 'windows'
+        shell: powershell
+        run: |
+          # Get-ChildItem -File -Recurse -Path "C:\Program Files\Firebird\Firebird_3_0" -Name
+          $WinSysDir = [Environment]::SystemDirectory
+          $CurDir = Get-Location
+          $DestFile = Join-Path -Path $CurDir -ChildPath "fbclient.lib"
+          $Dirs = @(
+              "${WinSysDir}",
+              "C:\Program Files\Firebird\Firebird_3_0", 
+              "C:\Program Files\Firebird\Firebird_4_0", 
+              "C:\Program Files\Firebird\Firebird_2_5"
+              )
+          $Libs = @( 
+              "fbclient_ms.lib", 
+              "fbclient.lib", 
+              "lib\fbclient_ms.lib", 
+              "lib\fbclient.lib", 
+              "WOW64\lib\fbclient_ms.lib", 
+              "WOW64\lib\fbclient.lib" 
+              )
+          Foreach ($dr in $Dirs) {
+            Foreach ($lb in $Libs) {
+              $Source = Join-Path -Path $dr -ChildPath $lb
+              echo "Searching for $Source"
+              if (Test-Path $Source -PathType Leaf) {
+                echo "Coying $Source to $DestFile"
+                Copy-Item -Path $Source -Destination $DestFile
+                return
+              }
+            }
+          }
+          echo "fbclient.lib not found !!!"
+          return 1
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -90,7 +141,6 @@ jobs:
           docker exec firebirdsql /bin/bash '/usr/local/firebird/bin/createAliasDB.sh' 'test.fdb' '/firebird/data/test.fdb'
           docker container restart firebirdsql
           echo '# Restarted container firebirdsql'
-          sleep 10
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -100,18 +150,19 @@ jobs:
           default: true
 
       - name: Install cli and development library
+        if: matrix.plataform == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends firebird3.0-utils firebird-dev
 
       - name: Testing Connection and Query
-        if: matrix.firebird != 'v4'
+        if: matrix.firebird != 'v4' && matrix.plataform == 'linux'
         run: |
           SQL1='select RDB$CHARACTER_SET_NAME as charset_sysdba from rdb$database;' 
           echo $SQL1 | isql-fb -bail -quiet -z -user SYSDBA -password masterkey 'localhost:/firebird/data/test.fdb'
 
       - name: Testing Connection for User test_user on fb v3
-        if: matrix.firebird == 'v3'
+        if: matrix.firebird == 'v3' && matrix.plataform == 'linux'
         run: |
           SQL2='select RDB$CHARACTER_SET_NAME as charset_user from rdb$database;' 
           echo $SQL2 | isql-fb -bail -quiet -z -user test_user -password test_password 'localhost:test.fdb'
@@ -142,6 +193,7 @@ jobs:
           # flag-name: run-${{ matrix.firebird }}-${{ matrix.build }}
 
       - name: Cleanup docker and coverage
+        if: matrix.plataform == 'linux'
         run: |
           docker rm --volumes --force firebirdsql
           rm -f ./lcov.info

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -111,9 +111,10 @@ jobs:
                 "${WinSysDir}"
                 )
             Foreach ($folder in $CommonDirs) {
+              echo "# Finding relevant files in FirebirdSQL install:"
               $found = Get-ChildItem -File -Recurse -Path $folder -Include $FileName -ea 0
               Foreach ($source in $found) {
-                echo "Found: $source"
+                echo "  - $source"
               }
             }
           }
@@ -173,7 +174,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features '${{ matrix.features }}' -- --test-threads 1
+          args: --no-default-features --features '${{ matrix.features }}' -- --test-threads 1
           # TODO: args: --features '${{ matrix.features }}'
 
       - name: Run cargo-tarpaulin
@@ -184,7 +185,7 @@ jobs:
           version: "latest"
           run-types: "AllTargets"
           out-type: "Lcov"
-          args: -v --line --count --branch --features '${{ matrix.features }}' -- --test-threads 1
+          args: -v --line --count --branch --no-default-features --features '${{ matrix.features }}' -- --test-threads 1
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
@@ -250,7 +251,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features '${{ matrix.features }}' -- --test-threads 1
+          args: --no-default-features --features '${{ matrix.features }}' -- --test-threads 1
 
   security:
     name: security

--- a/rsfbclient-native/Cargo.toml
+++ b/rsfbclient-native/Cargo.toml
@@ -16,3 +16,6 @@ libloading = { version = "0.6", optional = true }
 [features]
 linking = []
 dynamic_loading = ["libloading"]
+
+[build-dependencies]
+glob = "0.3.0"

--- a/rsfbclient-native/build.rs
+++ b/rsfbclient-native/build.rs
@@ -1,4 +1,6 @@
 fn main() {
     #[cfg(feature = "linking")]
-    println!("cargo:rustc-link-lib=dylib=fbclient");
+    // println!("cargo:rustc-link-lib=dylib=fbclient");
+    // println!("cargo:rustc-link-lib=fbclient");
+    println!("cargo:rustc-link-search=native=C:\\Program Files\\Firebird\\Firebird_3_0\\lib\\");    
 }

--- a/rsfbclient-native/build.rs
+++ b/rsfbclient-native/build.rs
@@ -1,6 +1,73 @@
+// build.rs
+
 fn main() {
-    #[cfg(feature = "linking")]
-    // println!("cargo:rustc-link-lib=dylib=fbclient");
-    // println!("cargo:rustc-link-lib=fbclient");
-    println!("cargo:rustc-link-search=native=C:\\Program Files\\Firebird\\Firebird_3_0\\lib\\");    
+    if search_on_environment_var() {
+        #[cfg(all(feature = "linking", target_os = "linux"))]
+        search_on_linux();
+
+        #[cfg(all(feature = "linking", target_os = "windows"))]
+        search_on_windows();
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 }
+
+fn search_on_environment_var() -> bool {
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-searchkindpath
+
+    if let Ok(user_specified_dir) = std::env::var("FBCLIENT_LIB_DIR") {
+        println!("cargo:rustc-link-search={}", user_specified_dir);
+        return false;
+    }
+    return true;
+}
+
+#[cfg(all(feature = "linking", target_os = "linux"))]
+fn search_on_linux() {
+    // https://doc.rust-lang.org/rustc/command-line-arguments.html#option-l-link-lib
+
+    println!("cargo:rustc-link-lib=dylib=fbclient");
+}
+
+#[cfg(all(feature = "linking", target_os = "windows"))]
+fn search_on_windows() {
+    let fbclient_lib_names: [&str; 2] = ["fbclient.lib", "fbclient_ms.lib"];
+    for fbclient_lib in &fbclient_lib_names {
+        if let Some(found) = search_for_file(fbclient_lib) {
+            println!("cargo:rustc-link-lib=dylib={}", found);
+            return;
+        }
+    }
+}
+
+#[cfg(all(feature = "linking", target_os = "windows"))]
+use glob::glob;
+
+#[cfg(all(feature = "linking", target_os = "windows"))]
+fn search_for_file(filename: &str) -> Option<String> {
+    // https://kornel.ski/rust-sys-crate#find
+
+    let firebird_install_dirs: [&str; 5] = [
+        "C:\\Program Files\\Firebird\\Firebird_3_0",
+        "C:\\Program Files\\Firebird\\Firebird*",
+        "C:\\Firebird*",
+        "D:\\Firebird*",
+        "C:\\Windows\\System*",
+    ];
+
+    for install_dir in &firebird_install_dirs {
+        let pattern = format!("{}\\**\\{}", install_dir, filename);
+        let found = glob(&pattern).expect("Failed to read glob pattern");
+
+        for entry in found {
+            if let Ok(path) = entry {
+                if path.is_file() {
+                    let fp = path.to_str().unwrap();
+                    return Some(fp.to_string());
+                }
+            }
+        }
+    }
+    return None;
+}
+
+// end of code

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -66,14 +66,26 @@ macro_rules! mk_tests_default {
 
             #[cfg(all(feature = "dynamic_loading", not(feature = "embedded_tests")))]
             for dynamic_loading -> Connection<rsfbclient_native::NativeFbClient> {
-                crate::ConnectionBuilder::with_client("libfbclient.so")
+
+                #[cfg(target_os = "linux")]
+                let libfbclient = "libfbclient.so";
+                #[cfg(target_os = "windows")]
+                let libfbclient = "fbclient.dll";
+
+                crate::ConnectionBuilder::with_client(libfbclient)
                         .connect()
                         .expect("Error on connect the test database")
             }
 
             #[cfg(all(feature = "dynamic_loading", feature = "embedded_tests"))]
             for dynamic_loading_embedded -> Connection<rsfbclient_native::NativeFbClient> {
-                crate::ConnectionBuilder::with_client("libfbclient.so")
+
+                #[cfg(target_os = "linux")]
+                let libfbclient = "libfbclient.so";
+                #[cfg(target_os = "windows")]
+                let libfbclient = "fbclient.dll";
+
+                crate::ConnectionBuilder::with_client(libfbclient)
                         .embedded()
                         .db_name("/tmp/embedded_tests.fdb")
                         .connect()


### PR DESCRIPTION
### ci: run tests on windows

Continued from #31.

What's missing yet:

- `cargo tarpaulin` is disabled because it's failing on some path issue.
- `embedded` test case is not enabled.
