### PR TITLE
Refactorations

### DIFF
--- a/rsfbclient-native/src/lib.rs
+++ b/rsfbclient-native/src/lib.rs
@@ -6,5 +6,6 @@ pub(crate) mod params;
 pub(crate) mod row;
 pub(crate) mod status;
 pub(crate) mod xsqlda;
+pub(crate) mod varchar;
 
 pub use connection::{Args, NativeFbClient};

--- a/rsfbclient-native/src/lib.rs
+++ b/rsfbclient-native/src/lib.rs
@@ -5,7 +5,7 @@ pub(crate) mod ibase;
 pub(crate) mod params;
 pub(crate) mod row;
 pub(crate) mod status;
-pub(crate) mod xsqlda;
 pub(crate) mod varchar;
+pub(crate) mod xsqlda;
 
 pub use connection::{Args, NativeFbClient};

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -216,7 +216,7 @@ fn blobtext_to_string(
 ) -> Result<String, FbError> {
     let blob_bytes = read_blob(buffer, db, tr, ibase)?;
 
-    charset.decode(&blob_bytes)
+    charset.decode(blob_bytes)
 }
 
 /// Read the blob type

--- a/rsfbclient-native/src/varchar.rs
+++ b/rsfbclient-native/src/varchar.rs
@@ -19,10 +19,12 @@ unsafe impl Send for Varchar {}
 impl Varchar {
     /// Allocate a new varchar buffer
     pub fn new(capacity: u16) -> Self {
-        let ptr = ptr::NonNull::new(unsafe {
-            alloc::alloc_zeroed(layout(capacity as usize)) as *mut InnerVarchar
+        let mut ptr = ptr::NonNull::new(unsafe {
+            alloc::alloc(layout(capacity as usize)) as *mut InnerVarchar
         })
         .unwrap();
+
+        unsafe { ptr.as_mut().len = 0 };
 
         Varchar { capacity, ptr }
     }

--- a/rsfbclient-native/src/varchar.rs
+++ b/rsfbclient-native/src/varchar.rs
@@ -1,0 +1,57 @@
+use std::{alloc, mem, ptr};
+
+#[repr(C)]
+/// Structure expected by the `fbclient`
+pub struct InnerVarchar {
+    len: u16,
+    data: [u8; 0],
+}
+
+#[derive(Debug)]
+/// Wrapper for a varchar buffer
+pub struct Varchar {
+    capacity: u16,
+    ptr: ptr::NonNull<InnerVarchar>,
+}
+
+unsafe impl Send for Varchar {}
+
+impl Varchar {
+    /// Allocate a new varchar buffer
+    pub fn new(capacity: u16) -> Self {
+        let ptr = ptr::NonNull::new(unsafe {
+            alloc::alloc_zeroed(layout(capacity as usize)) as *mut InnerVarchar
+        })
+        .unwrap();
+
+        Varchar { capacity, ptr }
+    }
+
+    /// Get the received bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = u16::min(self.capacity, unsafe { self.ptr.as_ref().len }) as usize;
+
+        unsafe { self.ptr.as_ref().data.get_unchecked(..len) }
+    }
+
+    /// Get the pointer to the inner type
+    pub fn as_ptr(&self) -> *mut InnerVarchar {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for Varchar {
+    fn drop(&mut self) {
+        unsafe {
+            alloc::dealloc(self.ptr.as_ptr() as *mut u8, layout(self.capacity as usize));
+        }
+    }
+}
+
+fn layout(len: usize) -> alloc::Layout {
+    alloc::Layout::from_size_align(
+        mem::size_of::<InnerVarchar>() + len,
+        mem::align_of::<InnerVarchar>(),
+    )
+    .unwrap()
+}

--- a/rsfbclient-rust/src/consts.rs
+++ b/rsfbclient-rust/src/consts.rs
@@ -196,6 +196,7 @@ impl AuthPluginType {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 /// Converts a gds_code to a error message
 pub fn gds_to_msg(gds_code: u32) -> &'static str {
     match gds_code {

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -536,7 +536,7 @@ pub fn parse_fetch_response(
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Text(charset.decode(&d.to_vec())?)),
+                        Some(ColumnType::Text(charset.decode(&d[..])?)),
                     )))
                 }
             }
@@ -693,7 +693,7 @@ impl ParsedColumn {
                 id,
                 col_name,
             } => {
-                let mut data = BytesMut::new();
+                let mut data = Vec::with_capacity(256);
 
                 let blob_handle = conn.open_blob(tr_handle, id)?;
 
@@ -712,9 +712,9 @@ impl ParsedColumn {
                 Column::new(
                     col_name,
                     Some(if binary {
-                        ColumnType::Binary(data.freeze().to_vec())
+                        ColumnType::Binary(data)
                     } else {
-                        ColumnType::Text(conn.charset.decode(&data.freeze().to_vec())?)
+                        ColumnType::Text(conn.charset.decode(data)?)
                     }),
                 )
             }

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -9,7 +9,7 @@ mk_tests_default! {
     use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
     use rsfbclient_core::ColumnToVal;
     use std::str;
-    use rand::{distributions::{Alphanumeric, Standard}, Rng};
+    use rand::{distributions::Standard, Rng};
 
     #[test]
     fn boolean() -> Result<(), FbError> {

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -91,7 +91,7 @@ mk_tests_default! {
         let mut conn = cbuilder().connect()?;
 
         let rstr: String = rand::thread_rng()
-            .sample_iter(Alphanumeric)
+            .sample_iter::<char, _>(Standard)
             .take(10000)
             .collect();
 


### PR DESCRIPTION
In the first commit, changes the encoding and decoding code to avoid copying data where possible by using the `Cow` type.

In the second, change the way data is sent / received from the `fbclient` library to make sure all data is properly aligned by allocating the exact data type expected in the rust side, instead of a byte buffer in all cases.