### PR TITLE
Simplify `Queryable` trait

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -450,8 +450,6 @@ impl<C> Queryable for Connection<C>
 where
     C: FirebirdClient,
 {
-    // type Iter = StmtIter<'a, R, C>;
-
     /// Prepare, execute, return the rows and commit the sql query
     ///
     /// Use `()` for no parameters or a tuple of parameters

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,23 +7,25 @@
 use rsfbclient_core::{FbError, FromRow, IntoParams};
 
 /// Implemented for types that can be used to execute sql queries
-pub trait Queryable<'a, R>
+pub trait Queryable<R>
 where
-    R: FromRow + 'a,
+    R: FromRow,
 {
-    type Iter: Iterator<Item = Result<R, FbError>> + 'a;
-
     /// Returns the results of the query as an iterator
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    fn query_iter<P>(&'a mut self, sql: &str, params: P) -> Result<Self::Iter, FbError>
+    fn query_iter<'a, P>(
+        &'a mut self,
+        sql: &str,
+        params: P,
+    ) -> Result<Box<dyn Iterator<Item = Result<R, FbError>> + 'a>, FbError>
     where
         P: IntoParams;
 
     /// Returns the results of the query as a `Vec`
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    fn query<P>(&'a mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
+    fn query<'a, P>(&'a mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
     where
         P: IntoParams,
     {
@@ -33,7 +35,7 @@ where
     /// Returns the first result of the query, or None
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    fn query_first<P>(&'a mut self, sql: &str, params: P) -> Result<Option<R>, FbError>
+    fn query_first<'a, P>(&'a mut self, sql: &str, params: P) -> Result<Option<R>, FbError>
     where
         P: IntoParams,
     {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -128,8 +128,6 @@ impl<'c, C> Queryable for Transaction<'c, C>
 where
     C: FirebirdClient,
 {
-    // type Iter = StmtIter<'a, R, C>;
-
     /// Prepare, execute and return the rows of the sql query
     ///
     /// Use `()` for no parameters or a tuple of parameters

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -124,17 +124,21 @@ where
     }
 }
 
-impl<'a, R, C> Queryable<'a, R> for Transaction<'a, C>
+impl<'c, R, C> Queryable<R> for Transaction<'c, C>
 where
-    R: FromRow + 'a,
+    R: FromRow + 'c,
     C: FirebirdClient,
 {
-    type Iter = StmtIter<'a, R, C>;
+    // type Iter = StmtIter<'a, R, C>;
 
     /// Prepare, execute and return the rows of the sql query
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    fn query_iter<P>(&'a mut self, sql: &str, params: P) -> Result<Self::Iter, FbError>
+    fn query_iter<'a, P>(
+        &'a mut self,
+        sql: &str,
+        params: P,
+    ) -> Result<Box<dyn Iterator<Item = Result<R, FbError>> + 'a>, FbError>
     where
         P: IntoParams,
     {
@@ -156,7 +160,7 @@ where
                     _marker: Default::default(),
                 };
 
-                Ok(iter)
+                Ok(Box::new(iter))
             }
             Err(e) => {
                 // Return the statement to the cache


### PR DESCRIPTION
Removed lifetime and trait bounds from the trait itself.

Closes #51 