### PR TITLE
RFC/WIP: abstracting over attachment types and their arguments

### DIFF
--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -4,12 +4,14 @@ use num_enum::TryFromPrimitive;
 
 use crate::*;
 
-pub trait FirebirdClientEmbeddedAttach: FirebirdClient {
+pub trait FirebirdClientEmbeddedAttach {
+    type DbHandle;
     /// Connect to a database, returning a database handle
     fn attach_database(&mut self, db_name: &str, user: &str) -> Result<Self::DbHandle, FbError>;
 }
 
-pub trait FirebirdClientRemoteAttach: FirebirdClient {
+pub trait FirebirdClientRemoteAttach {
+    type DbHandle;
     /// Connect to a database, returning a database handle
     fn attach_database(
         &mut self,
@@ -19,6 +21,54 @@ pub trait FirebirdClientRemoteAttach: FirebirdClient {
         user: &str,
         pass: &str,
     ) -> Result<Self::DbHandle, FbError>;
+}
+
+pub struct ConnectionArgsEmbedded {
+    pub user: String,
+    pub db_name: String,
+}
+pub struct ConnectionArgsRemote {
+    host: String,
+    user: String,
+    db_name: String,
+    port: u16,
+    pass: String,
+}
+
+pub trait FBAttach<A> {
+    type ConnArgs;
+    type T;
+    fn attach_database(&mut self, connargs: &Self::ConnArgs) -> Result<Self::T, FbError>;
+}
+
+pub struct Embedded;
+pub struct Remote;
+
+impl<A: FirebirdClientEmbeddedAttach> FBAttach<Embedded> for A {
+    type ConnArgs = ConnectionArgsEmbedded;
+    type T = <Self as FirebirdClientEmbeddedAttach>::DbHandle;
+
+    fn attach_database(&mut self, connargs: &Self::ConnArgs) -> Result<Self::T, FbError> {
+        let db_name = connargs.db_name.as_str();
+        let user = connargs.user.as_str();
+
+        <Self as FirebirdClientEmbeddedAttach>::attach_database(self, db_name, user)
+    }
+}
+
+impl<A: FirebirdClientRemoteAttach> FBAttach<Remote> for A {
+    type ConnArgs = ConnectionArgsRemote;
+    type T = <Self as FirebirdClientRemoteAttach>::DbHandle;
+
+    fn attach_database(&mut self, connargs: &Self::ConnArgs) -> Result<Self::T, FbError> {
+        let db_name = connargs.db_name.as_str();
+        let user = connargs.user.as_str();
+        let host = connargs.host.as_str();
+        let port = connargs.port;
+        let pass = connargs.pass.as_str();
+
+        <Self as FirebirdClientRemoteAttach>::attach_database(self, host, port, db_name, user, pass)
+    }
 }
 
 pub trait FirebirdClient: Send {
@@ -31,6 +81,13 @@ pub trait FirebirdClient: Send {
 
     /// Arguments to instantiate the client
     type Args: Send + Sync + Clone;
+
+    fn attach_database<A, B, C>(&mut self, args: &B) -> Result<C, FbError>
+    where
+        Self: FBAttach<A, ConnArgs = B, T = C>,
+    {
+        <Self as FBAttach<A>>::attach_database(self, args)
+    }
 
     fn new(charset: Charset, args: Self::Args) -> Result<Self, FbError>
     where

--- a/rsfbclient-core/src/impl_helper.rs
+++ b/rsfbclient-core/src/impl_helper.rs
@@ -1,0 +1,29 @@
+//! Helpers for abstracting over database attachment types
+
+use super::error::FbError;
+#[derive(Clone)]
+pub struct ConnectionArgsEmbedded {
+    pub user: String,
+    pub db_name: String,
+}
+#[derive(Clone)]
+pub struct ConnectionArgsRemote {
+    pub host: String,
+    pub user: String,
+    pub db_name: String,
+    pub port: u16,
+    pub pass: String,
+}
+
+pub struct Embedded {}
+pub struct Remote {}
+
+pub trait FirebirdClientAttach<A> {
+    /// The type of database handle to return
+    type DbHandle: Send;
+
+    /// Arguments needed to attach to the database
+    type ConnArgs: Send + Sync + Clone;
+
+    fn attach_database(&mut self, connargs: &Self::ConnArgs) -> Result<Self::DbHandle, FbError>;
+}

--- a/rsfbclient-core/src/lib.rs
+++ b/rsfbclient-core/src/lib.rs
@@ -7,6 +7,7 @@ mod connection;
 mod date_time;
 pub(crate) mod error;
 pub mod ibase;
+pub mod impl_helper;
 mod params;
 mod row;
 

--- a/rsfbclient-native/src/lib.rs
+++ b/rsfbclient-native/src/lib.rs
@@ -8,4 +8,4 @@ pub(crate) mod status;
 pub(crate) mod varchar;
 pub(crate) mod xsqlda;
 
-pub use connection::{Args, NativeFbClient};
+pub use connection::{NativeArgs, NativeFbClient};

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -56,6 +56,7 @@ struct StmtData {
 }
 
 impl FirebirdClientRemoteAttach for RustFbClient {
+    type DbHandle = <RustFbClient as FirebirdClient>::DbHandle;
     /// Attach to a database, creating the connections if necessary.
     ///
     /// It will only connect only once, so calling a second time with different


### PR DESCRIPTION
**Edit2**: I have reworked my approach. See subsequent commits/comments. I leave my existing comment here for reference.

it would be helpful if the main crate (and other implementations of the interface) didn't have to deal explicitly with three separate traits (`FirebirdClient`, `FirebirdClientRemoteAttach` and `FirebirdClientEmbeddedAttach`) so I made a parameterized attachment trait, currently called `FBAttach<A>` for this as an example. This approach I think ends up too complicated and I mention other approaches and variations at the end of this comment.

**Edit:** After thinking a bit more, the solution I described under "_Make the type of attachment arguments an associated type of FirebirdClient_" seems to be the cleanest and most flexible. I propose adding a type parameter as in `FirebirdClient<A>`, _as well as_ a `ConnArgs` associated type. The `ConnArgs` lets us give a type to `attach_database` inside `FirebirdClient`, and the `<A>` gives a lot of flexibility for multiple implementations and re-use (implementations can then choose to do things like `impl<A: AttachPart, B: FBClientPart>   FirebirdClient<(A,B)> for NativeFbClient {...<B as FBClientPart>::somemethod().. }` ) 


For the `FBAttach<A>` trait  I added a method to `FirebirdClient` with signature
```
attach_database<A,B,C>(&mut self, args: &B) -> Result<C,FbErr>`
where Self: FBAttach<A,ConnArgs=B,DbHandle=C>
```
these types in the `where...` are associated types of `FBAttach<A>`. The type parameter `A` is what allows multiple attachment type implementations for a single client implementation. `B` is some type representing the arguments for the attachment type. `C` is just `FirebirdClient::DbHandle` but duplicated in `FBAttach<A>` for reasons explained a bit later. We could get rid of `C` here with a few changes.

This way all instances of `FirebirdClient + FirebirdClientXAttach` can just be replaced by `FirebirdClient`.
Implementers of core will still need to know about different attachments, but with this they could also write their own attachment type if they want to, completely different from remote or embedded (if I use my imagination: one reason to do so is to write a shim for another DBMS)

I re-used the `FirebirdClientXAttach` trait implementations for now so I didn't have to rewrite as much in the native and pure rust crates.
To help understanding, the calls proceed as
`FirdbirdClient::attach_database -> FBAttach<A>::attach_database -> FirebirdClientXAttach::attach_database`

now of course the builder will still have to build the arguments, but I think there are probably several crates with builder-derive macros that could be used for the structs.

If desired, it would actually be possible to prevent implementations of `FBAttach<A>` except for `A = Remote` or `A = Embedded` but I see no reason to do so

in this commit I also took the opportunity to combine the two connection type implementations into `attach_database_remote_or_embedded` for `NativeFbClient` and make the trait impls refer to that

`FirebirdClient` and other traits in core also no longer have dependencies on one another in the trait signature.
Unfortunately this has the effect of making `FirebirdClient::DbHandle` inaccessible in these other traits

but we could just pull the associated types into another trait (parameterized so it can have multiple implementations easily)
like this
```
trait FBClientTypes<A> {
    /// A database handle
    type DbHandle: Send + Clone + Copy;
    /// A transaction handle
    type TrHandle: Send + Clone + Copy;
    /// A statement handle
    type StmtHandle: Send + Clone + Copy;

    /// Arguments to instantiate the client
    type Args: Send + Sync + Clone;
}

trait FirebirdClient {
  type DbHandle;
  ...
}
```
implementations would then be required to add things like
```
impl trait FirebirdClient {
  type DbHandle = <NativeFbClient as FBClientTypes<A>>::DbHandle;
  ...
}
```
or just define the types outside any trait and re-use them inside the traits.
This would allow having multiple `FirebirdClient` implementations for a single type as well.

### Other approaches and variations
#### Newtype wrappers
we forget about parameterized traits and just have implementations use newtype wrappers instead, so there is only one `FirebirdClientAttach` trait and we do something like ```struct RemoteNativeFbClient(NativeFbClient);``` (this is guaranteed zero-cost in rust)

where we want to provide different ways of using a particular implementation.

This would make `rsfbclient-core` simpler but maybe make `rsfbclient-native` more complicated (a naive approach would require implementing `FirebirdClient` once per wrapper), though maybe we could use some tricks to get around that like `impl<A:FirebirdClient, B:BorrowMut<A>> FirebirdClient for B` in core so implementations don't have to do as much work
       
#### Make the type of attachment arguments an associated type of FirebirdClient
Similar to what I've implemented in my example, except we just totally get rid of extra attachment traits and add either an associated type for the arguments in `FirebirdClient`, or add a type parameter to get `FirebirdClient<AttachArgs>` similar to what has been done for `Firebirdclient::Args` , with a method similar to what I did for `FirebirdClient::attach_database`.

#### Export a single trait which combines `FirebirdClient` with an attachment trait
like `pub trait FirebirdClientWithAttach : FirebirdClient + Attach {}` (or maybe `FirebirdClientWithAttach<A>` for added flexibility)
so an implementer can write `impl FirebirdClient for NativeFbClient<Remote> {...}`, `impl Attach for NativeFbClient<Remote> {...}` `impl FirebirdClientWithAttach for NativeFbClient<Remote> {}` or something like that, and then also similarly for `NativeFbClient<Embedded>`. The down side is that putting parameters directly on structs like this requires `PhantomData` inside. This can be circumvented using trait machinery by implementers but then we're just back to making things complicated again.
 a sub-variation of this is adding parameters to both `Attach` and `FirebirdClient` then writing in core `impl<A, B: FirebirdClient<A> + Attach<A> > FirebirdClientWithAttach<A> for B`
