### PR TITLE
Named columns refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = "0.7.3"
 
 [features]
 default = ["linking", "date_time", "pool"]
-date_time = ["rsfbclient-core/date_time", "chrono"]
+date_time = ["rsfbclient-core/date_time", "rsfbclient-native/date_time", "rsfbclient-rust/date_time", "chrono"]
 dynamic_loading = ["rsfbclient-native/dynamic_loading"]
 linking = ["rsfbclient-native/linking"]
 embedded_tests = []

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -86,7 +86,7 @@ pub trait FirebirdClient: Send {
         db_handle: Self::DbHandle,
         tr_handle: Self::TrHandle,
         stmt_handle: Self::StmtHandle,
-        params: Vec<Param>,
+        params: Vec<SqlType>,
     ) -> Result<(), FbError>;
 
     /// Fetch rows from the executed statement, coercing the types

--- a/rsfbclient-core/src/date_time.rs
+++ b/rsfbclient-core/src/date_time.rs
@@ -112,7 +112,7 @@ pub fn encode_timestamp(dt: NaiveDateTime) -> ibase::ISC_TIMESTAMP {
 
 impl IntoParam for NaiveDateTime {
     fn into_param(self) -> SqlType {
-        SqlType::Timestamp(encode_timestamp(self))
+        SqlType::Timestamp(self)
     }
 }
 
@@ -133,7 +133,7 @@ impl IntoParam for NaiveTime {
 impl ColumnToVal<chrono::NaiveDate> for Column {
     fn to_val(self) -> Result<chrono::NaiveDate, FbError> {
         match self.value {
-            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).date()),
+            SqlType::Timestamp(ts) => Ok(ts.date()),
 
             SqlType::Null => Err(err_column_null("NaiveDate")),
 
@@ -145,7 +145,7 @@ impl ColumnToVal<chrono::NaiveDate> for Column {
 impl ColumnToVal<chrono::NaiveTime> for Column {
     fn to_val(self) -> Result<chrono::NaiveTime, FbError> {
         match self.value {
-            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).time()),
+            SqlType::Timestamp(ts) => Ok(ts.time()),
 
             SqlType::Null => Err(err_column_null("NaiveTime")),
 
@@ -157,7 +157,7 @@ impl ColumnToVal<chrono::NaiveTime> for Column {
 impl ColumnToVal<chrono::NaiveDateTime> for Column {
     fn to_val(self) -> Result<chrono::NaiveDateTime, FbError> {
         match self.value {
-            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts)),
+            SqlType::Timestamp(ts) => Ok(ts),
 
             SqlType::Null => Err(err_column_null("NaiveDateTime")),
 

--- a/rsfbclient-core/src/date_time.rs
+++ b/rsfbclient-core/src/date_time.rs
@@ -2,7 +2,7 @@ use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
 use crate::{
     error::{err_column_null, err_type_conv},
-    ibase, Column, ColumnToVal, ColumnType, FbError, IntoParam, Param,
+    ibase, Column, ColumnToVal, FbError, IntoParam, SqlType,
 };
 
 const FRACTION_TO_NANOS: u32 = 1e9 as u32 / ibase::ISC_TIME_SECONDS_PRECISION;
@@ -111,20 +111,20 @@ pub fn encode_timestamp(dt: NaiveDateTime) -> ibase::ISC_TIMESTAMP {
 }
 
 impl IntoParam for NaiveDateTime {
-    fn into_param(self) -> Param {
-        Param::Timestamp(encode_timestamp(self))
+    fn into_param(self) -> SqlType {
+        SqlType::Timestamp(encode_timestamp(self))
     }
 }
 
 impl IntoParam for NaiveDate {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         // Mimics firebird conversion
         self.and_time(NaiveTime::from_hms(0, 0, 0)).into_param()
     }
 }
 
 impl IntoParam for NaiveTime {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         // Mimics firebird conversion
         chrono::Utc::today().naive_utc().and_time(self).into_param()
     }
@@ -132,36 +132,36 @@ impl IntoParam for NaiveTime {
 
 impl ColumnToVal<chrono::NaiveDate> for Column {
     fn to_val(self) -> Result<chrono::NaiveDate, FbError> {
-        let col = self.value.ok_or_else(|| err_column_null("NaiveDate"))?;
+        match self.value {
+            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).date()),
 
-        match col {
-            ColumnType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).date()),
+            SqlType::Null => Err(err_column_null("NaiveDate")),
 
-            _ => err_type_conv(col, "NaiveDate"),
+            col => err_type_conv(col, "NaiveDate"),
         }
     }
 }
 
 impl ColumnToVal<chrono::NaiveTime> for Column {
     fn to_val(self) -> Result<chrono::NaiveTime, FbError> {
-        let col = self.value.ok_or_else(|| err_column_null("NaiveTime"))?;
+        match self.value {
+            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).time()),
 
-        match col {
-            ColumnType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).time()),
+            SqlType::Null => Err(err_column_null("NaiveTime")),
 
-            _ => err_type_conv(col, "NaiveTime"),
+            col => err_type_conv(col, "NaiveTime"),
         }
     }
 }
 
 impl ColumnToVal<chrono::NaiveDateTime> for Column {
     fn to_val(self) -> Result<chrono::NaiveDateTime, FbError> {
-        let col = self.value.ok_or_else(|| err_column_null("NaiveDateTime"))?;
+        match self.value {
+            SqlType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts)),
 
-        match col {
-            ColumnType::Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts)),
+            SqlType::Null => Err(err_column_null("NaiveDateTime")),
 
-            _ => err_type_conv(col, "NaiveDateTime"),
+            col => err_type_conv(col, "NaiveDateTime"),
         }
     }
 }

--- a/rsfbclient-core/src/error.rs
+++ b/rsfbclient-core/src/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::ColumnType;
+use crate::SqlType;
 
 #[derive(Debug, Error)]
 pub enum FbError {
@@ -35,7 +35,7 @@ pub fn err_column_null(type_name: &str) -> FbError {
     ))
 }
 
-pub fn err_type_conv<T>(from: ColumnType, to: &str) -> Result<T, FbError> {
+pub fn err_type_conv<T>(from: SqlType, to: &str) -> Result<T, FbError> {
     Err(FbError::Other(format!(
         "Can't convert {:?} column to {}",
         from, to

--- a/rsfbclient-core/src/lib.rs
+++ b/rsfbclient-core/src/lib.rs
@@ -15,3 +15,32 @@ pub use connection::*;
 pub use error::FbError;
 pub use params::*;
 pub use row::*;
+
+#[derive(Debug, Clone)]
+/// Sql parameter / column data
+pub enum SqlType {
+    Text(String),
+
+    Integer(i64),
+
+    Floating(f64),
+
+    Timestamp(ibase::ISC_TIMESTAMP),
+
+    Binary(Vec<u8>),
+
+    /// Only works in fb >= 3.0
+    Boolean(bool),
+
+    Null,
+}
+
+impl SqlType {
+    /// Returns `true` if the type is `NULL`
+    pub fn is_null(&self) -> bool {
+        match self {
+            Null => true,
+            _ => false,
+        }
+    }
+}

--- a/rsfbclient-core/src/lib.rs
+++ b/rsfbclient-core/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod charset;
 mod connection;
 #[cfg(feature = "date_time")]
-mod date_time;
+pub mod date_time;
 pub(crate) mod error;
 pub mod ibase;
 mod params;
@@ -25,7 +25,8 @@ pub enum SqlType {
 
     Floating(f64),
 
-    Timestamp(ibase::ISC_TIMESTAMP),
+    #[cfg(feature = "date_time")]
+    Timestamp(chrono::NaiveDateTime),
 
     Binary(Vec<u8>),
 

--- a/rsfbclient-core/src/params.rs
+++ b/rsfbclient-core/src/params.rs
@@ -1,31 +1,13 @@
 //! Sql parameter types and traits
 
-use crate::ibase;
+use crate::{ibase, SqlType};
 
-use Param::*;
+pub use SqlType::*;
 
 /// Max length that can be sent without creating a BLOB
 pub const MAX_TEXT_LENGTH: usize = 32767;
 
-/// Sql parameter data
-pub enum Param {
-    Text(String),
-
-    Integer(i64),
-
-    Floating(f64),
-
-    Timestamp(ibase::ISC_TIMESTAMP),
-
-    Null,
-
-    Binary(Vec<u8>),
-
-    /// Only works in fb >= 3.0
-    Boolean(bool),
-}
-
-impl Param {
+impl SqlType {
     /// Return the sql type to coerce the data
     pub fn sql_type_and_subtype(&self) -> (u32, u32) {
         match self {
@@ -44,42 +26,33 @@ impl Param {
             Boolean(_) => (ibase::SQL_BOOLEAN + 1, 0),
         }
     }
-
-    /// Return true if null
-    pub fn is_null(&self) -> bool {
-        if let Self::Null = self {
-            true
-        } else {
-            false
-        }
-    }
 }
 
 /// Implemented for types that can be sent as parameters
 pub trait IntoParam {
-    fn into_param(self) -> Param;
+    fn into_param(self) -> SqlType;
 }
 
 impl IntoParam for Vec<u8> {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         Binary(self)
     }
 }
 
 impl IntoParam for String {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         Text(self)
     }
 }
 
 impl IntoParam for i64 {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         Integer(self)
     }
 }
 
 impl IntoParam for bool {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         Boolean(self)
     }
 }
@@ -89,7 +62,7 @@ macro_rules! impl_param_int {
     ( $( $t: ident ),+ ) => {
         $(
             impl IntoParam for $t {
-                fn into_param(self) -> Param {
+                fn into_param(self) -> SqlType {
                     (self as i64).into_param()
                 }
             }
@@ -100,13 +73,13 @@ macro_rules! impl_param_int {
 impl_param_int!(i32, u32, i16, u16, i8, u8);
 
 impl IntoParam for f64 {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         Floating(self)
     }
 }
 
 impl IntoParam for f32 {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         (self as f64).into_param()
     }
 }
@@ -116,7 +89,7 @@ impl<T> IntoParam for Option<T>
 where
     T: IntoParam,
 {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         if let Some(v) = self {
             v.into_param()
         } else {
@@ -131,13 +104,13 @@ where
     B: ToOwned<Owned = T> + ?Sized,
     T: core::borrow::Borrow<B> + IntoParam,
 {
-    fn into_param(self) -> Param {
+    fn into_param(self) -> SqlType {
         self.to_owned().into_param()
     }
 }
 
 /// Implement From / Into conversions
-impl<T> From<T> for Param
+impl<T> From<T> for SqlType
 where
     T: IntoParam,
 {
@@ -148,20 +121,20 @@ where
 
 /// Implemented for types that represents a list of parameters
 pub trait IntoParams {
-    fn to_params(self) -> Vec<Param>;
+    fn to_params(self) -> Vec<SqlType>;
 }
 
 /// Allow use of a vector instead of tuples, for when the number of parameters are unknow at compile time
 /// or more parameters are needed than what can be used with the tuples
-impl IntoParams for Vec<Param> {
-    fn to_params(self) -> Vec<Param> {
+impl IntoParams for Vec<SqlType> {
+    fn to_params(self) -> Vec<SqlType> {
         self
     }
 }
 
 /// Represents no parameters
 impl IntoParams for () {
-    fn to_params(self) -> Vec<Param> {
+    fn to_params(self) -> Vec<SqlType> {
         vec![]
     }
 }
@@ -173,7 +146,7 @@ macro_rules! impl_into_params {
         where
             $( $t: IntoParam, )+
         {
-            fn to_params(self) -> Vec<Param> {
+            fn to_params(self) -> Vec<SqlType> {
                 let ( $($v,)+ ) = self;
 
                 vec![ $(

--- a/rsfbclient-core/src/row.rs
+++ b/rsfbclient-core/src/row.rs
@@ -63,12 +63,7 @@ impl ColumnToVal<String> for Column {
             Floating(f) => Ok(f.to_string()),
 
             #[cfg(feature = "date_time")]
-            Timestamp(ts) => Ok(crate::date_time::decode_timestamp(ts).to_string()),
-
-            #[cfg(not(feature = "date_time"))]
-            Timestamp(_) => {
-                Err("Enable the `date_time` feature to use Timestamp, Date and Time types".into())
-            }
+            Timestamp(ts) => Ok(ts.to_string()),
 
             Binary(_) => Err("This is a binary column. You cannot use string to access".into()),
 

--- a/rsfbclient-native/Cargo.toml
+++ b/rsfbclient-native/Cargo.toml
@@ -16,6 +16,7 @@ libloading = { version = "0.6", optional = true }
 [features]
 linking = []
 dynamic_loading = ["libloading"]
+date_time = ["rsfbclient-core/date_time"]
 
 [build-dependencies]
 glob = "0.3.0"

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -383,7 +383,7 @@ impl FirebirdClient for NativeFbClient {
         mut db_handle: Self::DbHandle,
         mut tr_handle: Self::TrHandle,
         mut stmt_handle: Self::StmtHandle,
-        params: Vec<Param>,
+        params: Vec<SqlType>,
     ) -> Result<(), FbError> {
         let _ = self
             .stmt_data_map

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -170,17 +170,27 @@ impl ParamBuffer {
 
                 (bytes.len(), Text(bytes.into_boxed_slice()))
             }
+
             SqlType::Integer(i) => (mem::size_of_val(&i), Integer(Box::new(i))),
+
             SqlType::Floating(f) => (mem::size_of_val(&f), Floating(Box::new(f))),
-            SqlType::Timestamp(ts) => (mem::size_of_val(&ts), Timestamp(Box::new(ts))),
+
+            #[cfg(feature = "date_time")]
+            SqlType::Timestamp(dt) => (
+                mem::size_of_val(&dt),
+                Timestamp(Box::new(rsfbclient_core::date_time::encode_timestamp(dt))),
+            ),
+
             SqlType::Null => {
                 null = -1;
                 (0, Null)
             }
+
             SqlType::Binary(bin) => {
                 let bytes = binary_to_blob(&bin, db, tr, ibase)?;
                 (bytes.len(), Binary(bytes.into_boxed_slice()))
             }
+
             SqlType::Boolean(bo) => (mem::size_of::<i8>(), Boolean(Box::new(bo as i8))),
         };
 

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -1,7 +1,7 @@
 use std::{mem, ptr};
 
 use crate::{ibase, ibase::IBase, status::Status, xsqlda::XSqlDa};
-use rsfbclient_core::{Charset, FbError, Param, MAX_TEXT_LENGTH};
+use rsfbclient_core::{Charset, FbError, SqlType, MAX_TEXT_LENGTH};
 
 use ParamBufferData::*;
 
@@ -22,7 +22,7 @@ impl Params {
         ibase: &ibase::IBase,
         status: &mut Status,
         stmt_handle: &mut ibase::isc_stmt_handle,
-        infos: Vec<Param>,
+        infos: Vec<SqlType>,
         charset: &Charset,
     ) -> Result<Self, FbError> {
         let params = if !infos.is_empty() {
@@ -144,7 +144,7 @@ impl ParamBufferData {
 impl ParamBuffer {
     /// Allocate a buffer from a value to use in an input (parameter) XSQLVAR
     pub fn from_parameter(
-        info: Param,
+        info: SqlType,
         var: &mut ibase::XSQLVAR,
         db: &mut ibase::isc_db_handle,
         tr: &mut ibase::isc_tr_handle,
@@ -159,7 +159,7 @@ impl ParamBuffer {
         var.sqlscale = 0;
 
         let (size, mut buffer) = match info {
-            Param::Text(s) => {
+            SqlType::Text(s) => {
                 let bytes = charset.encode(s)?;
 
                 let bytes = if bytes.len() > MAX_TEXT_LENGTH {
@@ -170,18 +170,18 @@ impl ParamBuffer {
 
                 (bytes.len(), Text(bytes.into_boxed_slice()))
             }
-            Param::Integer(i) => (mem::size_of_val(&i), Integer(Box::new(i))),
-            Param::Floating(f) => (mem::size_of_val(&f), Floating(Box::new(f))),
-            Param::Timestamp(ts) => (mem::size_of_val(&ts), Timestamp(Box::new(ts))),
-            Param::Null => {
+            SqlType::Integer(i) => (mem::size_of_val(&i), Integer(Box::new(i))),
+            SqlType::Floating(f) => (mem::size_of_val(&f), Floating(Box::new(f))),
+            SqlType::Timestamp(ts) => (mem::size_of_val(&ts), Timestamp(Box::new(ts))),
+            SqlType::Null => {
                 null = -1;
                 (0, Null)
             }
-            Param::Binary(bin) => {
+            SqlType::Binary(bin) => {
                 let bytes = binary_to_blob(&bin, db, tr, ibase)?;
                 (bytes.len(), Binary(bytes.into_boxed_slice()))
             }
-            Param::Boolean(bo) => (mem::size_of::<i8>(), Boolean(Box::new(bo as i8))),
+            SqlType::Boolean(bo) => (mem::size_of::<i8>(), Boolean(Box::new(bo as i8))),
         };
 
         let mut nullind = Box::new(null);

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -176,10 +176,11 @@ impl ParamBuffer {
             SqlType::Floating(f) => (mem::size_of_val(&f), Floating(Box::new(f))),
 
             #[cfg(feature = "date_time")]
-            SqlType::Timestamp(dt) => (
-                mem::size_of_val(&dt),
-                Timestamp(Box::new(rsfbclient_core::date_time::encode_timestamp(dt))),
-            ),
+            SqlType::Timestamp(dt) => {
+                let ts = rsfbclient_core::date_time::encode_timestamp(dt);
+
+                (mem::size_of_val(&ts), Timestamp(Box::new(ts)))
+            }
 
             SqlType::Null => {
                 null = -1;

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -176,7 +176,8 @@ impl ColumnBuffer {
 
             Float(f) => SqlType::Floating(**f),
 
-            Timestamp(ts) => SqlType::Timestamp(**ts),
+            #[cfg(feature = "date_time")]
+            Timestamp(ts) => SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(**ts)),
 
             BlobText(b) => SqlType::Text(blobtext_to_string(**b, db, tr, ibase, &charset)?),
 

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -4,7 +4,7 @@
 //! Representation of a fetched row
 //!
 
-use rsfbclient_core::{Charset, Column, ColumnType, FbError};
+use rsfbclient_core::{Charset, Column, FbError, SqlType};
 use std::{mem, result::Result};
 
 use crate::{ibase, ibase::IBase, status::Status, varchar::Varchar};
@@ -166,26 +166,26 @@ impl ColumnBuffer {
         charset: &Charset,
     ) -> Result<Column, FbError> {
         if *self.nullind != 0 {
-            return Ok(Column::new(self.col_name.clone(), None));
+            return Ok(Column::new(self.col_name.clone(), SqlType::Null));
         }
 
         let col_type = match &self.buffer {
-            Text(varchar) => ColumnType::Text(charset.decode(varchar.as_bytes())?),
+            Text(varchar) => SqlType::Text(charset.decode(varchar.as_bytes())?),
 
-            Integer(i) => ColumnType::Integer(**i),
+            Integer(i) => SqlType::Integer(**i),
 
-            Float(f) => ColumnType::Float(**f),
+            Float(f) => SqlType::Floating(**f),
 
-            Timestamp(ts) => ColumnType::Timestamp(**ts),
+            Timestamp(ts) => SqlType::Timestamp(**ts),
 
-            BlobText(b) => ColumnType::Text(blobtext_to_string(**b, db, tr, ibase, &charset)?),
+            BlobText(b) => SqlType::Text(blobtext_to_string(**b, db, tr, ibase, &charset)?),
 
-            BlobBinary(b) => ColumnType::Binary(blobbinary_to_vec(**b, db, tr, ibase)?),
+            BlobBinary(b) => SqlType::Binary(blobbinary_to_vec(**b, db, tr, ibase)?),
 
-            Boolean(b) => ColumnType::Boolean(**b != 0),
+            Boolean(b) => SqlType::Boolean(**b != 0),
         };
 
-        Ok(Column::new(self.col_name.clone(), Some(col_type)))
+        Ok(Column::new(self.col_name.clone(), col_type))
     }
 }
 

--- a/rsfbclient-rust/Cargo.toml
+++ b/rsfbclient-rust/Cargo.toml
@@ -25,3 +25,4 @@ sha2 = "0.9.1"
 
 [features]
 fuzz_testing = []
+date_time = ["rsfbclient-core/date_time"]

--- a/rsfbclient-rust/src/blr.rs
+++ b/rsfbclient-rust/src/blr.rs
@@ -1,6 +1,6 @@
 use crate::{client::FirebirdWireConnection, consts};
 use bytes::{BufMut, Bytes, BytesMut};
-use rsfbclient_core::{FbError, Param};
+use rsfbclient_core::{FbError, SqlType};
 
 /// Maximum parameter data length
 pub const MAX_DATA_LENGTH: usize = 32767;
@@ -18,7 +18,7 @@ pub struct ParamsBlr {
 pub fn params_to_blr(
     conn: &mut FirebirdWireConnection,
     tr_handle: crate::TrHandle,
-    params: &[Param],
+    params: &[SqlType],
 ) -> Result<ParamsBlr, FbError> {
     let mut blr = BytesMut::with_capacity(256);
     let mut values = BytesMut::with_capacity(256);
@@ -58,7 +58,7 @@ pub fn params_to_blr(
 
     for p in params {
         match p {
-            Param::Text(s) => {
+            SqlType::Text(s) => {
                 let bytes = conn.charset.encode(s)?;
                 if bytes.len() > MAX_DATA_LENGTH {
                     // Data too large, send as blob
@@ -75,9 +75,9 @@ pub fn params_to_blr(
                 }
             }
 
-            Param::Binary(data) => handle_blob(conn, &mut blr, &mut values, &data)?,
+            SqlType::Binary(data) => handle_blob(conn, &mut blr, &mut values, &data)?,
 
-            Param::Integer(i) => {
+            SqlType::Integer(i) => {
                 blr.put_slice(&[
                     consts::blr::INT64,
                     0, // Scale
@@ -86,26 +86,26 @@ pub fn params_to_blr(
                 values.put_i64(*i);
             }
 
-            Param::Floating(f) => {
+            SqlType::Floating(f) => {
                 blr.put_u8(consts::blr::DOUBLE);
 
                 values.put_f64(*f);
             }
 
-            Param::Timestamp(ts) => {
+            SqlType::Timestamp(ts) => {
                 blr.put_u8(consts::blr::TIMESTAMP);
 
                 values.put_i32(ts.timestamp_date);
                 values.put_u32(ts.timestamp_time);
             }
 
-            Param::Boolean(b) => {
+            SqlType::Boolean(b) => {
                 blr.put_u8(consts::blr::BOOL);
 
                 values.put_slice(if *b { &[1, 0, 0, 0] } else { &[0, 0, 0, 0] });
             }
 
-            Param::Null => {
+            SqlType::Null => {
                 // Represent as empty text
                 blr.put_u8(consts::blr::TEXT);
                 blr.put_u16_le(0);
@@ -136,7 +136,7 @@ pub fn params_to_blr(
 /// or 1 if it is, and so forth.
 ///
 /// Needs to be aligned to 4 bytes, so processing in chunks of 32 parameters (4 bytes = 32 bits)
-fn null_bitmap(values: &mut BytesMut, params: &[Param]) {
+fn null_bitmap(values: &mut BytesMut, params: &[SqlType]) {
     for bitmap in params.chunks(32).map(|params| {
         params.iter().enumerate().fold(0, |bitmap, (i, p)| {
             if p.is_null() {

--- a/rsfbclient-rust/src/blr.rs
+++ b/rsfbclient-rust/src/blr.rs
@@ -92,9 +92,11 @@ pub fn params_to_blr(
                 values.put_f64(*f);
             }
 
-            SqlType::Timestamp(ts) => {
+            #[cfg(feature = "date_time")]
+            SqlType::Timestamp(dt) => {
                 blr.put_u8(consts::blr::TIMESTAMP);
 
+                let ts = rsfbclient_core::date_time::encode_timestamp(*dt);
                 values.put_i32(ts.timestamp_date);
                 values.put_u32(ts.timestamp_time);
             }

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use rsfbclient_core::{
     ibase, Charset, Column, Dialect, FbError, FirebirdClient, FirebirdClientRemoteAttach,
-    FreeStmtOp, Param, StmtType, TrIsolationLevel, TrOp,
+    FreeStmtOp, SqlType, StmtType, TrIsolationLevel, TrOp,
 };
 
 /// Firebird client implemented in rust
@@ -185,7 +185,7 @@ impl FirebirdClient for RustFbClient {
         _db_handle: Self::DbHandle,
         tr_handle: Self::TrHandle,
         stmt_handle: Self::StmtHandle,
-        params: Vec<Param>,
+        params: Vec<SqlType>,
     ) -> Result<(), FbError> {
         self.conn
             .as_mut()
@@ -513,7 +513,7 @@ impl FirebirdWireConnection {
         &mut self,
         tr_handle: TrHandle,
         stmt_handle: StmtHandle,
-        params: &[Param],
+        params: &[SqlType],
     ) -> Result<(), FbError> {
         if let Some(StmtData { param_count, .. }) = self.stmt_data_map.get_mut(&stmt_handle) {
             if params.len() != *param_count {

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -11,7 +11,7 @@ use crate::{
     srp::*,
     xsqlda::{XSqlVar, XSQLDA_DESCRIBE_VARS},
 };
-use rsfbclient_core::{ibase, Charset, Column, ColumnType, FbError, FreeStmtOp, TrOp};
+use rsfbclient_core::{ibase, Charset, Column, FbError, FreeStmtOp, SqlType, TrOp};
 
 /// Buffer length to use in the connection
 pub const BUFFER_LENGTH: u32 = 1024;
@@ -515,7 +515,7 @@ pub fn parse_fetch_response(
             // There is no data in protocol 13 if null, so just continue
             data.push(ParsedColumn::Complete(Column::new(
                 var.alias_name.clone(),
-                None,
+                SqlType::Null,
             )));
             continue;
         }
@@ -531,12 +531,12 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Text(charset.decode(&d[..])?)),
+                        SqlType::Text(charset.decode(&d[..])?),
                     )))
                 }
             }
@@ -552,12 +552,12 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Integer(i)),
+                        SqlType::Integer(i),
                     )))
                 }
             }
@@ -573,12 +573,12 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Float(f)),
+                        SqlType::Floating(f),
                     )))
                 }
             }
@@ -597,12 +597,12 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Timestamp(ts)),
+                        SqlType::Timestamp(ts),
                     )))
                 }
             }
@@ -618,7 +618,7 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Blob {
@@ -641,12 +641,12 @@ pub fn parse_fetch_response(
                 if null {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        None,
+                        SqlType::Null,
                     )))
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        Some(ColumnType::Boolean(b)),
+                        SqlType::Boolean(b),
                     )))
                 }
             }
@@ -711,11 +711,11 @@ impl ParsedColumn {
 
                 Column::new(
                     col_name,
-                    Some(if binary {
-                        ColumnType::Binary(data)
+                    if binary {
+                        SqlType::Binary(data)
                     } else {
-                        ColumnType::Text(conn.charset.decode(data)?)
-                    }),
+                        SqlType::Text(conn.charset.decode(data)?)
+                    },
                 )
             }
         })

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -583,6 +583,7 @@ pub fn parse_fetch_response(
                 }
             }
 
+            #[cfg(feature = "date_time")]
             ibase::SQL_TIMESTAMP => {
                 if resp.remaining() < 8 {
                     return err_invalid_response();
@@ -602,7 +603,7 @@ pub fn parse_fetch_response(
                 } else {
                     data.push(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
-                        SqlType::Timestamp(ts),
+                        SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
                     )))
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,7 @@ pub use crate::{
     statement::Statement,
     transaction::Transaction,
 };
-pub use rsfbclient_core::{
-    charset, Column, ColumnType, Dialect, FbError, FromRow, IntoParam, Param, Row,
-};
+pub use rsfbclient_core::{charset, Column, Dialect, FbError, FromRow, IntoParam, Row, SqlType};
 
 #[cfg(feature = "pool")]
 pub use crate::connection::pool::FirebirdConnectionManager;

--- a/src/tests/params.rs
+++ b/src/tests/params.rs
@@ -5,7 +5,7 @@
 //!
 
 mk_tests_default! {
-    use crate::{prelude::*, FbError, Param};
+    use crate::{prelude::*, FbError, SqlType};
     use chrono::{NaiveDate, NaiveTime};
     use rand::{distributions::Standard, Rng};
 
@@ -290,7 +290,7 @@ mk_tests_default! {
 
         let vals = -250..250;
 
-        let params: Vec<Param> = vals.clone().map(|v| v.into()).collect();
+        let params: Vec<SqlType> = vals.clone().map(|v| v.into()).collect();
 
         let sql = format!("select 1 from rdb$database where {}", vals.fold(String::new(), |mut acc, v| {
             if acc.is_empty() {

--- a/src/tests/transaction.rs
+++ b/src/tests/transaction.rs
@@ -29,9 +29,8 @@ mk_tests_default! {
       let mut setup_transaction = Transaction::new(&conn)?;
       setup_transaction.execute_immediate( format!(drop_tbl_fmtstring!(), table_name ).as_str() )?;
       setup_transaction.commit()?;
-      let close_result = conn.close();
 
-      close_result
+      conn.close()
   }
 
   #[test]


### PR DESCRIPTION
Simplifications to the api to allow users to easily match the `value` property of the `Column` struct when using named columns