### PR TITLE
Refactoring backend configuration abstractions

### DIFF
--- a/rsfbclient-native/src/lib.rs
+++ b/rsfbclient-native/src/lib.rs
@@ -1,6 +1,6 @@
 //! `FirebirdConnection` implementation for the native fbclient
 
-mod connection;
+pub mod connection;
 pub(crate) mod ibase;
 pub(crate) mod params;
 pub(crate) mod row;
@@ -8,4 +8,4 @@ pub(crate) mod status;
 pub(crate) mod varchar;
 pub(crate) mod xsqlda;
 
-pub use connection::{Args, NativeFbClient};
+pub use connection::NativeFbClient;

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -2,6 +2,7 @@
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::{
+    borrow::Borrow,
     collections::HashMap,
     env,
     io::{Read, Write},
@@ -17,15 +18,31 @@ use crate::{
     xsqlda::{parse_xsqlda, xsqlda_to_blr, PrepareInfo, XSqlVar},
 };
 use rsfbclient_core::{
-    ibase, Charset, Column, Dialect, FbError, FirebirdClient, FirebirdClientRemoteAttach,
-    FreeStmtOp, SqlType, StmtType, TrIsolationLevel, TrOp,
+    ibase, Charset, Column, Dialect, FbError, FirebirdClient, FirebirdClientDbOps,
+    FirebirdClientSqlOps, FreeStmtOp, SqlType, StmtType, TrIsolationLevel, TrOp,
 };
+
+type RustDbHandle = DbHandle;
+type RustTrHandle = TrHandle;
+type RustStmtHandle = StmtHandle;
 
 /// Firebird client implemented in rust
 pub struct RustFbClient {
     conn: Option<FirebirdWireConnection>,
-
     charset: Charset,
+}
+
+pub trait Builder<A> {
+    fn set(&mut self, val: A) -> &mut Self;
+}
+
+#[derive(Default, Clone)]
+pub struct RustFbClientAttachmentConfig {
+    pub host: String,
+    pub port: u16,
+    pub db_name: String,
+    pub user: String,
+    pub pass: String,
 }
 
 /// A Connection to a firebird server
@@ -55,19 +72,29 @@ struct StmtData {
     param_count: usize,
 }
 
-impl FirebirdClientRemoteAttach for RustFbClient {
-    /// Attach to a database, creating the connections if necessary.
-    ///
-    /// It will only connect only once, so calling a second time with different
-    /// host or port will still use the old connection.
+impl RustFbClient {
+    pub fn new(charset: Charset) -> Result<Self, FbError> {
+        Ok(Self {
+            conn: None,
+            charset,
+        })
+    }
+}
+
+impl FirebirdClientDbOps for RustFbClient {
+    type DbHandle = RustDbHandle;
+    type AttachmentConfig = RustFbClientAttachmentConfig;
+
     fn attach_database(
         &mut self,
-        host: &str,
-        port: u16,
-        db_name: &str,
-        user: &str,
-        pass: &str,
-    ) -> Result<Self::DbHandle, FbError> {
+        config: &Self::AttachmentConfig,
+    ) -> Result<RustDbHandle, FbError> {
+        let host = config.host.as_str();
+        let port = config.port;
+        let db_name = config.db_name.as_str();
+        let user = config.user.as_str();
+        let pass = config.pass.as_str();
+
         // Take the existing connection, or connects
         let mut conn = match self.conn.take() {
             Some(conn) => conn,
@@ -88,38 +115,26 @@ impl FirebirdClientRemoteAttach for RustFbClient {
 
         attach_result
     }
-}
 
-impl FirebirdClient for RustFbClient {
-    type DbHandle = DbHandle;
-    type TrHandle = TrHandle;
-    type StmtHandle = StmtHandle;
-
-    type Args = ();
-
-    fn new(charset: Charset, _args: Self::Args) -> Result<Self, FbError>
-    where
-        Self: Sized,
-    {
-        Ok(Self {
-            conn: None,
-            charset,
-        })
-    }
-
-    fn detach_database(&mut self, db_handle: Self::DbHandle) -> Result<(), FbError> {
+    fn detach_database(&mut self, db_handle: RustDbHandle) -> Result<(), FbError> {
         self.conn
             .as_mut()
             .map(|conn| conn.detach_database(db_handle))
             .unwrap_or_else(err_client_not_connected)
     }
 
-    fn drop_database(&mut self, db_handle: Self::DbHandle) -> Result<(), FbError> {
+    fn drop_database(&mut self, db_handle: RustDbHandle) -> Result<(), FbError> {
         self.conn
             .as_mut()
             .map(|conn| conn.drop_database(db_handle))
             .unwrap_or_else(err_client_not_connected)
     }
+}
+
+impl FirebirdClientSqlOps for RustFbClient {
+    type DbHandle = RustDbHandle;
+    type TrHandle = RustTrHandle;
+    type StmtHandle = RustStmtHandle;
 
     fn begin_transaction(
         &mut self,

--- a/rsfbclient-rust/src/lib.rs
+++ b/rsfbclient-rust/src/lib.rs
@@ -8,7 +8,7 @@ mod srp;
 mod wire;
 mod xsqlda;
 
-pub use client::{DbHandle, RustFbClient, StmtHandle, TrHandle};
+pub use client::{DbHandle, RustFbClient, RustFbClientAttachmentConfig, StmtHandle, TrHandle};
 
 #[cfg(feature = "fuzz_testing")]
 pub use self::{blr::*, wire::*, xsqlda::*};

--- a/src/connection/builder.rs
+++ b/src/connection/builder.rs
@@ -1,0 +1,219 @@
+use super::{ConnectionConfiguration, FirebirdClientFactory};
+use crate::charset::{Charset, UTF_8};
+use crate::{Connection, Dialect, FbError};
+use rsfbclient_core::FirebirdClient;
+
+impl<Cli: FirebirdClient> ConnectionConfiguration<Cli> {
+    /// Open a new connection to the database
+    pub fn connect<F: FirebirdClientFactory<C = Cli>>(
+        &self,
+        factory: F,
+    ) -> Result<Connection<F::C>, FbError> {
+        Connection::open(factory.new()?, self)
+    }
+}
+
+#[cfg(feature = "linking")]
+pub mod native_static_client {
+    use super::*;
+    use rsfbclient_native::connection::{NativeFbClient, RemoteConfig};
+    struct StaticLinked(Charset);
+
+    fn static_linked_client(charset: Charset) -> StaticLinked {
+        StaticLinked(charset)
+    }
+    impl FirebirdClientFactory for StaticLinked {
+        type C = NativeFbClient;
+        fn new(&self) -> Result<Self::C, FbError> {
+            NativeFbClient::new_static_linked(self.0.clone())
+        }
+    }
+}
+
+#[cfg(feature = "dynamic_loading")]
+pub mod native_dynlinked_client {
+    use super::*;
+    use rsfbclient_native::connection::{NativeFbClient, RemoteConfig};
+    struct DynLinked(Charset, String);
+    fn dyn_linked_client<S: Into<String>>(charset: Charset, path: S) -> DynLinked {
+        DynLinked(charset, path.into())
+    }
+
+    impl FirebirdClientFactory for DynLinked {
+        type C = NativeFbClient;
+        fn new(&self) -> Result<Self::C, FbError> {
+            NativeFbClient::new_dyn_linked(self.0.clone(), &self.1)
+        }
+    }
+}
+
+#[cfg(any(feature = "linking", feature = "dynamic_loading"))]
+pub mod native_builder {
+    use super::*;
+    use rsfbclient_native::connection::{NativeFbClient, RemoteConfig};
+
+    type NativeConfig = ConnectionConfiguration<NativeFbClient>;
+    impl NativeConfig {
+        /// Username. Default: SYSDBA
+        pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
+            self.attachment_conf.user = user.into();
+            self
+        }
+
+        /// Database name or path. Default: test.fdb
+        pub fn db_name<S: Into<String>>(&mut self, db_name: S) -> &mut Self {
+            self.attachment_conf.db_name = db_name.into();
+            self
+        }
+
+        fn get_initialized_remote(&mut self) -> &mut RemoteConfig {
+            self.attachment_conf
+                .remote
+                .get_or_insert(Default::default())
+        }
+
+        /// Hostname or IP address of the server. Default: localhost
+        pub fn host<S: Into<String>>(&mut self, host: S) -> &mut Self {
+            self.get_initialized_remote().host = host.into();
+            self
+        }
+
+        /// TCP Port of the server. Default: 3050
+        pub fn port(&mut self, port: u16) -> &mut Self {
+            self.get_initialized_remote().port = port;
+            self
+        }
+        ///
+        /// Password. Default: masterkey
+        pub fn pass<S: Into<String>>(&mut self, pass: S) -> &mut Self {
+            self.get_initialized_remote().password = pass.into();
+            self
+        }
+
+        /// SQL Dialect. Default: 3
+        pub fn dialect(&mut self, dialect: Dialect) -> &mut Self {
+            self.dialect = dialect;
+            self
+        }
+
+        /// Statement cache size. Default: 20
+        pub fn stmt_cache_size(&mut self, stmt_cache_size: usize) -> &mut Self {
+            self.stmt_cache_size = stmt_cache_size;
+            self
+        }
+
+        pub fn embedded_default() -> Self {
+            EmbeddedNativeConfig::default().0
+        }
+
+        pub fn remote_default() -> Self {
+            RemoteNativeConfig::default().0
+        }
+    }
+
+    struct EmbeddedNativeConfig(NativeConfig);
+
+    impl Default for EmbeddedNativeConfig {
+        fn default() -> Self {
+            let attachment_conf = Default::default();
+            let mut result = NativeConfig {
+                attachment_conf,
+                dialect: Dialect::D3,
+                stmt_cache_size: 20,
+            };
+            result.user("SYDBA").db_name("test.fdb");
+            EmbeddedNativeConfig(result)
+        }
+    }
+
+    struct RemoteNativeConfig(NativeConfig);
+    impl Default for RemoteNativeConfig {
+        fn default() -> Self {
+            let EmbeddedNativeConfig(mut conf) = EmbeddedNativeConfig::default();
+            conf.host("localhost").port(3050).pass("masterkey");
+            RemoteNativeConfig(conf)
+        }
+    }
+}
+
+#[cfg(feature = "pure_rust")]
+pub mod pure_rust_builder {
+    use super::*;
+    use rsfbclient_rust::{RustFbClient, RustFbClientAttachmentConfig};
+
+    pub struct PureRustClientConfig(Charset);
+
+    impl FirebirdClientFactory for PureRustClientConfig {
+        type C = RustFbClient;
+        fn new(&self) -> Result<Self::C, FbError> {
+            RustFbClient::new(self.0.clone())
+        }
+    }
+
+    fn pure_rust_client(charset: Charset) -> PureRustClientConfig {
+        PureRustClientConfig(charset)
+    }
+
+    type PureRustConfig = ConnectionConfiguration<rsfbclient_rust::RustFbClient>;
+    impl PureRustConfig {
+        /// Username. Default: SYSDBA
+        pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
+            self.attachment_conf.user = user.into();
+            self
+        }
+
+        /// Database name or path. Default: test.fdb
+        pub fn db_name<S: Into<String>>(&mut self, db_name: S) -> &mut Self {
+            self.attachment_conf.db_name = db_name.into();
+            self
+        }
+
+        /// Hostname or IP address of the server. Default: localhost
+        pub fn host<S: Into<String>>(&mut self, host: S) -> &mut Self {
+            self.attachment_conf.host = host.into();
+            self
+        }
+
+        /// TCP Port of the server. Default: 3050
+        pub fn port(&mut self, port: u16) -> &mut Self {
+            self.attachment_conf.port = port;
+            self
+        }
+        ///
+        /// Password. Default: masterkey
+        pub fn pass<S: Into<String>>(&mut self, pass: S) -> &mut Self {
+            self.attachment_conf.pass = pass.into();
+            self
+        }
+
+        /// SQL Dialect. Default: 3
+        pub fn dialect(&mut self, dialect: Dialect) -> &mut Self {
+            self.dialect = dialect;
+            self
+        }
+
+        /// Statement cache size. Default: 20
+        pub fn stmt_cache_size(&mut self, stmt_cache_size: usize) -> &mut Self {
+            self.stmt_cache_size = stmt_cache_size;
+            self
+        }
+    }
+
+    impl Default for PureRustConfig {
+        fn default() -> Self {
+            let attachment_conf = Default::default();
+            let mut result = Self {
+                attachment_conf,
+                dialect: Dialect::D3,
+                stmt_cache_size: 20,
+            };
+            result
+                .host("localhost")
+                .port(3050)
+                .user("SYDBA")
+                .db_name("test.fdb")
+                .pass("masterkey");
+            result
+        }
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,343 +4,57 @@
 //! Connection functions
 //!
 
+mod builder;
 #[cfg(feature = "pool")]
 pub mod pool;
 pub mod stmt_cache;
 
-use rsfbclient_core::{
-    charset::Charset, charset::UTF_8, Dialect, FbError, FirebirdClient,
-    FirebirdClientEmbeddedAttach, FirebirdClientRemoteAttach, FromRow, IntoParams,
-};
+use rsfbclient_core::{Dialect, FbError, FirebirdClient, FirebirdClientDbOps, FromRow, IntoParams};
 use std::{cell::RefCell, marker};
 
 use crate::{query::Queryable, statement::StatementData, Execute, Transaction};
 use stmt_cache::{StmtCache, StmtCacheData};
 
-/// The default builder for creating database connections
-pub struct ConnectionBuilder<C: FirebirdClient> {
-    host: String,
-    port: u16,
-    pass: String,
-    db_name: String,
-    user: String,
+pub trait FirebirdClientFactory: Send + Sync {
+    type C: FirebirdClient;
+    fn new(&self) -> Result<Self::C, FbError>;
+}
+
+#[derive(Clone)]
+pub struct ConnectionConfiguration<C: FirebirdClient> {
+    attachment_conf: C::AttachmentConfig,
     dialect: Dialect,
     stmt_cache_size: usize,
-    cli_args: C::Args,
-    _cli_type: marker::PhantomData<C>,
-    charset: Charset,
-}
-
-/// The builder for creating database connections using the embedded firebird
-pub struct ConnectionBuilderEmbedded<C: FirebirdClient> {
-    db_name: String,
-    user: String,
-    dialect: Dialect,
-    stmt_cache_size: usize,
-    cli_args: C::Args,
-    _cli_type: marker::PhantomData<C>,
-    charset: Charset,
-}
-
-/// The `PhantomMarker` makes it not Sync, but it is not true,
-/// as the `ConnectionBuilder` does not store `C`
-unsafe impl<C> Sync for ConnectionBuilder<C> where C: FirebirdClient {}
-unsafe impl<C> Sync for ConnectionBuilderEmbedded<C> where C: FirebirdClient {}
-
-impl<C> Clone for ConnectionBuilder<C>
-where
-    C: FirebirdClient,
-{
-    fn clone(&self) -> Self {
-        Self {
-            db_name: self.db_name.clone(),
-            pass: self.pass.clone(),
-            port: self.port,
-            host: self.host.clone(),
-            user: self.user.clone(),
-            dialect: self.dialect,
-            stmt_cache_size: self.stmt_cache_size,
-            cli_args: self.cli_args.clone(),
-            _cli_type: Default::default(),
-            charset: self.charset.clone(),
-        }
-    }
-}
-
-impl<C> Clone for ConnectionBuilderEmbedded<C>
-where
-    C: FirebirdClient,
-{
-    fn clone(&self) -> Self {
-        Self {
-            db_name: self.db_name.clone(),
-            user: self.user.clone(),
-            dialect: self.dialect,
-            stmt_cache_size: self.stmt_cache_size,
-            cli_args: self.cli_args.clone(),
-            _cli_type: Default::default(),
-            charset: self.charset.clone(),
-        }
-    }
-}
-
-#[cfg(any(feature = "linking", feature = "dynamic_loading"))]
-impl ConnectionBuilder<rsfbclient_native::NativeFbClient> {
-    #[cfg(feature = "linking")]
-    /// Uses the firebird client linked with the application at compile time
-    pub fn linked() -> Self {
-        Self {
-            host: "localhost".to_string(),
-            port: 3050,
-            db_name: "test.fdb".to_string(),
-            user: "SYSDBA".to_string(),
-            pass: "masterkey".to_string(),
-            dialect: Dialect::D3,
-            stmt_cache_size: 20,
-            cli_args: rsfbclient_native::Args::Linking,
-            _cli_type: Default::default(),
-            charset: UTF_8,
-        }
-    }
-
-    #[cfg(feature = "dynamic_loading")]
-    /// Searches for the firebird client at runtime, in the specified path.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use rsfbclient::ConnectionBuilder;
-    ///
-    /// // On windows
-    /// ConnectionBuilder::with_client("fbclient.dll");
-    ///
-    /// // On linux
-    /// ConnectionBuilder::with_client("libfbclient.so");
-    ///
-    /// // Any platform, file located relative to the
-    /// // folder where the executable was run
-    /// ConnectionBuilder::with_client("./fbclient.lib");
-    /// ```
-    pub fn with_client<S: Into<String>>(fbclient: S) -> Self {
-        Self {
-            host: "localhost".to_string(),
-            port: 3050,
-            db_name: "test.fdb".to_string(),
-            user: "SYSDBA".to_string(),
-            pass: "masterkey".to_string(),
-            dialect: Dialect::D3,
-            stmt_cache_size: 20,
-            cli_args: rsfbclient_native::Args::DynamicLoading {
-                lib_path: fbclient.into(),
-            },
-            _cli_type: Default::default(),
-            charset: UTF_8,
-        }
-    }
-
-    /// Force the embedded server utilization. Host, port and pass
-    /// will be ignored.
-    pub fn embedded(self) -> ConnectionBuilderEmbedded<rsfbclient_native::NativeFbClient> {
-        ConnectionBuilderEmbedded {
-            db_name: self.db_name,
-            user: self.user,
-            dialect: self.dialect,
-            stmt_cache_size: self.stmt_cache_size,
-            cli_args: self.cli_args,
-            _cli_type: Default::default(),
-            charset: UTF_8,
-        }
-    }
-}
-
-#[cfg(feature = "pure_rust")]
-impl ConnectionBuilder<rsfbclient_rust::RustFbClient> {
-    /// Uses the pure rust implementation of the firebird client
-    pub fn pure_rust() -> Self {
-        Self {
-            host: "localhost".to_string(),
-            port: 3050,
-            db_name: "test.fdb".to_string(),
-            user: "SYSDBA".to_string(),
-            pass: "masterkey".to_string(),
-            dialect: Dialect::D3,
-            stmt_cache_size: 20,
-            cli_args: (),
-            _cli_type: Default::default(),
-            charset: UTF_8,
-        }
-    }
-}
-
-impl<C> ConnectionBuilder<C>
-where
-    C: FirebirdClient + FirebirdClientRemoteAttach,
-{
-    /// Hostname or IP address of the server. Default: localhost
-    pub fn host<S: Into<String>>(&mut self, host: S) -> &mut Self {
-        self.host = host.into();
-        self
-    }
-
-    /// TCP Port of the server. Default: 3050
-    pub fn port(&mut self, port: u16) -> &mut Self {
-        self.port = port;
-        self
-    }
-
-    /// Database name or path. Default: test.fdb
-    pub fn db_name<S: Into<String>>(&mut self, db_name: S) -> &mut Self {
-        self.db_name = db_name.into();
-        self
-    }
-
-    /// Username. Default: SYSDBA
-    pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
-        self.user = user.into();
-        self
-    }
-
-    /// Password. Default: masterkey
-    pub fn pass<S: Into<String>>(&mut self, pass: S) -> &mut Self {
-        self.pass = pass.into();
-        self
-    }
-
-    /// SQL Dialect. Default: 3
-    pub fn dialect(&mut self, dialect: Dialect) -> &mut Self {
-        self.dialect = dialect;
-        self
-    }
-
-    /// Statement cache size. Default: 20
-    pub fn stmt_cache_size(&mut self, stmt_cache_size: usize) -> &mut Self {
-        self.stmt_cache_size = stmt_cache_size;
-        self
-    }
-
-    /// Charset. Default: UTF_8
-    pub fn charset(&mut self, charset: Charset) -> &mut Self {
-        self.charset = charset;
-        self
-    }
-
-    /// Open a new connection to the database
-    pub fn connect(&self) -> Result<Connection<C>, FbError> {
-        Connection::open_remote(self, C::new(self.charset.clone(), self.cli_args.clone())?)
-    }
-}
-
-impl<C> ConnectionBuilderEmbedded<C>
-where
-    C: FirebirdClient + FirebirdClientEmbeddedAttach,
-{
-    /// Database name or path. Default: test.fdb
-    pub fn db_name<S: Into<String>>(&mut self, db_name: S) -> &mut Self {
-        self.db_name = db_name.into();
-        self
-    }
-
-    /// Username. Default: SYSDBA
-    pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
-        self.user = user.into();
-        self
-    }
-
-    /// SQL Dialect. Default: 3
-    pub fn dialect(&mut self, dialect: Dialect) -> &mut Self {
-        self.dialect = dialect;
-        self
-    }
-
-    /// Statement cache size. Default: 20
-    pub fn stmt_cache_size(&mut self, stmt_cache_size: usize) -> &mut Self {
-        self.stmt_cache_size = stmt_cache_size;
-        self
-    }
-
-    /// Connection charset. It is only necessary to specify a charset other than the default `UTF-8` if you
-    /// have text stored in the database using columns with charset `NONE` or `OCTETS`. Otherwise
-    /// the database will handle the charset conversion automatically
-    pub fn charset(&mut self, charset: Charset) -> &mut Self {
-        self.charset = charset;
-        self
-    }
-
-    /// Open a new connection to the database
-    pub fn connect(&self) -> Result<Connection<C>, FbError> {
-        Connection::open_embedded(self, C::new(self.charset.clone(), self.cli_args.clone())?)
-    }
 }
 
 /// A connection to a firebird database
-pub struct Connection<C>
-where
-    C: FirebirdClient,
-{
+pub struct Connection<C: FirebirdClient> {
     /// Database handler
-    pub(crate) handle: C::DbHandle,
+    pub(crate) handle: <C as FirebirdClientDbOps>::DbHandle,
 
     /// Firebird dialect for the statements
     pub(crate) dialect: Dialect,
 
     /// Cache for the prepared statements
-    pub(crate) stmt_cache: RefCell<StmtCache<StatementData<C::StmtHandle>>>,
+    pub(crate) stmt_cache: RefCell<StmtCache<StatementData<C>>>,
 
     /// Firebird client
     pub(crate) cli: RefCell<C>,
 }
 
-impl<C> Connection<C>
-where
-    C: FirebirdClient + FirebirdClientRemoteAttach,
-{
-    /// Open a new connection to the database
-    fn open_remote(builder: &ConnectionBuilder<C>, mut cli: C) -> Result<Connection<C>, FbError> {
-        let handle = cli.attach_database(
-            &builder.host,
-            builder.port,
-            &builder.db_name,
-            &builder.user,
-            &builder.pass,
-        )?;
-
-        let stmt_cache = RefCell::new(StmtCache::new(builder.stmt_cache_size));
+impl<C: FirebirdClient> Connection<C> {
+    fn open(mut cli: C, conf: &ConnectionConfiguration<C>) -> Result<Connection<C>, FbError> {
+        let handle = cli.attach_database(&conf.attachment_conf)?;
+        let stmt_cache = RefCell::new(StmtCache::new(conf.stmt_cache_size));
 
         Ok(Connection {
             handle,
-            dialect: builder.dialect,
+            dialect: conf.dialect,
             stmt_cache,
             cli: RefCell::new(cli),
         })
     }
-}
 
-impl<C> Connection<C>
-where
-    C: FirebirdClient + FirebirdClientEmbeddedAttach,
-{
-    /// Open a new connection to the database
-    fn open_embedded(
-        builder: &ConnectionBuilderEmbedded<C>,
-        mut cli: C,
-    ) -> Result<Connection<C>, FbError> {
-        let handle = cli.attach_database(&builder.db_name, &builder.user)?;
-
-        let stmt_cache = RefCell::new(StmtCache::new(builder.stmt_cache_size));
-
-        Ok(Connection {
-            handle,
-            dialect: builder.dialect,
-            stmt_cache,
-            cli: RefCell::new(cli),
-        })
-    }
-}
-
-impl<C> Connection<C>
-where
-    C: FirebirdClient,
-{
     /// Drop the current database
     pub fn drop_database(mut self) -> Result<(), FbError> {
         self.cli.get_mut().drop_database(self.handle)?;
@@ -348,12 +62,21 @@ where
         Ok(())
     }
 
+    /// Close the current connection. With an `&mut self` to be used in the drop code too
+    fn close(&mut self) -> Result<(), FbError> {
+        self.stmt_cache.borrow_mut().close_all(self);
+
+        self.cli.get_mut().detach_database(self.handle)?;
+
+        Ok(())
+    }
+
     /// Run a closure with a transaction, if the closure returns an error
     /// the transaction will rollback, else it will be committed
-    pub fn with_transaction<T>(
-        &self,
-        closure: impl FnOnce(&mut Transaction<C>) -> Result<T, FbError>,
-    ) -> Result<T, FbError> {
+    pub fn with_transaction<T, F>(&self, closure: F) -> Result<T, FbError>
+    where
+        F: FnOnce(&mut Transaction<C>) -> Result<T, FbError>,
+    {
         let mut tr = Transaction::new(self)?;
 
         let res = closure(&mut tr);
@@ -366,35 +89,18 @@ where
 
         res
     }
-
-    /// Close the current connection
-    pub fn close(mut self) -> Result<(), FbError> {
-        self.__close()
-    }
-
-    /// Close the current connection. With an `&mut self` to be used in the drop code too
-    fn __close(&mut self) -> Result<(), FbError> {
-        self.stmt_cache.borrow_mut().close_all(self);
-
-        self.cli.get_mut().detach_database(self.handle)?;
-
-        Ok(())
-    }
 }
 
-impl<C> Drop for Connection<C>
-where
-    C: FirebirdClient,
-{
+impl<C: FirebirdClient> Drop for Connection<C> {
     fn drop(&mut self) {
-        self.__close().ok();
+        self.close().ok();
     }
 }
 
 /// Variant of the `StatementIter` that owns the `Transaction` and uses the statement cache
 pub struct StmtIter<'a, R, C: FirebirdClient> {
     /// Statement cache data. Wrapped in option to allow taking the value to send back to the cache
-    stmt_cache_data: Option<StmtCacheData<StatementData<C::StmtHandle>>>,
+    stmt_cache_data: Option<StmtCacheData<StatementData<C>>>,
 
     /// Transaction needs to be alive for the fetch to work
     tr: Transaction<'a, C>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod statement;
 mod transaction;
 
 pub use crate::{
-    connection::{Connection, ConnectionBuilder},
+    connection::Connection,
     query::{Execute, Queryable},
     statement::Statement,
     transaction::Transaction,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -11,7 +11,7 @@ use crate::{
 use rsfbclient_core::{Column, FbError, FirebirdClient, FreeStmtOp, FromRow, IntoParams, StmtType};
 
 pub struct Statement<'c, C: FirebirdClient> {
-    pub(crate) data: StatementData<C::StmtHandle>,
+    pub(crate) data: StatementData<C>,
     pub(crate) conn: &'c Connection<C>,
 }
 
@@ -73,7 +73,7 @@ where
 }
 /// Cursor to fetch the results of a statement
 pub struct StatementFetch<'s, R, C: FirebirdClient> {
-    pub(crate) stmt: &'s mut StatementData<C::StmtHandle>,
+    pub(crate) stmt: &'s mut StatementData<C>,
     /// Transaction needs to be alive for the fetch to work
     pub(crate) _tr: &'s Transaction<'s, C>,
     pub(crate) conn: &'s Connection<C>,
@@ -118,24 +118,21 @@ where
 /// Low level statement handler.
 ///
 /// Needs to be closed calling `close` before dropping.
-pub struct StatementData<H> {
-    pub(crate) handle: H,
+pub struct StatementData<C: FirebirdClient> {
+    pub(crate) handle: C::StmtHandle,
     pub(crate) stmt_type: StmtType,
 }
 
-impl<H> StatementData<H>
+impl<C: FirebirdClient> StatementData<C>
 where
-    H: Send + Clone + Copy,
+    C::StmtHandle: Send + Clone + Copy,
 {
     /// Prepare the statement that will be executed
-    pub fn prepare<C>(
+    pub fn prepare(
         conn: &Connection<C>,
-        tr: &mut TransactionData<C::TrHandle>,
+        tr: &mut TransactionData<C>,
         sql: &str,
-    ) -> Result<Self, FbError>
-    where
-        C: FirebirdClient<StmtHandle = H>,
-    {
+    ) -> Result<Self, FbError> {
         let (stmt_type, handle) =
             conn.cli
                 .borrow_mut()
@@ -147,15 +144,14 @@ where
     /// Execute the current statement without returnig any row
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    pub fn execute<T, C>(
+    pub fn execute<T>(
         &mut self,
         conn: &Connection<C>,
-        tr: &mut TransactionData<C::TrHandle>,
+        tr: &mut TransactionData<C>,
         params: T,
     ) -> Result<(), FbError>
     where
         T: IntoParams,
-        C: FirebirdClient<StmtHandle = H>,
     {
         conn.cli
             .borrow_mut()
@@ -173,15 +169,14 @@ where
     /// and returns the column buffer
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    pub fn query<'s, T, C>(
+    pub fn query<'s, T>(
         &'s mut self,
         conn: &'s Connection<C>,
-        tr: &mut TransactionData<C::TrHandle>,
+        tr: &mut TransactionData<C>,
         params: T,
     ) -> Result<(), FbError>
     where
         T: IntoParams,
-        C: FirebirdClient<StmtHandle = H>,
     {
         conn.cli
             .borrow_mut()
@@ -189,34 +184,25 @@ where
     }
 
     /// Fetch for the next row, needs to be called after `query`
-    pub fn fetch<C>(
+    pub fn fetch(
         &mut self,
         conn: &Connection<C>,
-        tr: &TransactionData<C::TrHandle>,
-    ) -> Result<Option<Vec<Column>>, FbError>
-    where
-        C: FirebirdClient<StmtHandle = H>,
-    {
+        tr: &TransactionData<C>,
+    ) -> Result<Option<Vec<Column>>, FbError> {
         conn.cli
             .borrow_mut()
             .fetch(conn.handle, tr.handle, self.handle)
     }
 
     /// Closes the statement cursor, if it was open
-    pub fn close_cursor<C>(&mut self, conn: &Connection<C>) -> Result<(), FbError>
-    where
-        C: FirebirdClient<StmtHandle = H>,
-    {
+    pub fn close_cursor(&mut self, conn: &Connection<C>) -> Result<(), FbError> {
         conn.cli
             .borrow_mut()
             .free_statement(self.handle, FreeStmtOp::Close)
     }
 
     /// Closes the statement
-    pub fn close<C>(&mut self, conn: &Connection<C>) -> Result<(), FbError>
-    where
-        C: FirebirdClient<StmtHandle = H>,
-    {
+    pub fn close(&mut self, conn: &Connection<C>) -> Result<(), FbError> {
         conn.cli
             .borrow_mut()
             .free_statement(self.handle, FreeStmtOp::Drop)


### PR DESCRIPTION
See commit message for details of changes

### TODO:
  * choose better names for things and decide on aspects of interface changes in main crate
  * fix up inline documentation (ie for rustdoc)
  * fix tests broken by changes
  * check and fix exports for added/moved items to ensure all the correct things show up in the public interface
  * check/fix backend method signatures in core traits (x:T vs x: &mut T)
  * scrutinize changes to types, especially with `XYZData` types in main crate.
    After making the backend changes, I had to make many trait bound and type parameter changes here in structs and methods.
    I only changed things enough to make the typechecker stop complaining, but I'm not sure everything is correct.

