### PR TITLE
Support for stmt execution without cursor

### DIFF
--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -89,6 +89,19 @@ pub trait FirebirdClient: Send {
         params: Vec<SqlType>,
     ) -> Result<(), FbError>;
 
+    /// Execute the prepared statement
+    /// with input and output parameters.
+    ///
+    /// The output parameters will be returned
+    /// as in the Result
+    fn execute2(
+        &mut self,
+        db_handle: Self::DbHandle,
+        tr_handle: Self::TrHandle,
+        stmt_handle: Self::StmtHandle,
+        params: Vec<SqlType>,
+    ) -> Result<Vec<Vec<Column>>, FbError>;
+
     /// Fetch rows from the executed statement, coercing the types
     /// according to the provided blr
     fn fetch(

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -100,7 +100,7 @@ pub trait FirebirdClient: Send {
         tr_handle: Self::TrHandle,
         stmt_handle: Self::StmtHandle,
         params: Vec<SqlType>,
-    ) -> Result<Vec<Vec<Column>>, FbError>;
+    ) -> Result<Vec<Column>, FbError>;
 
     /// Fetch rows from the executed statement, coercing the types
     /// according to the provided blr

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -350,7 +350,6 @@ impl FirebirdClient for NativeFbClient {
             })
             .collect::<Result<_, _>>()?;
 
-
         self.stmt_data_map.insert(handle, (xsqlda, col_buffers));
 
         Ok((stmt_type, handle))
@@ -490,7 +489,7 @@ impl FirebirdClient for NativeFbClient {
                 } else {
                     ptr::null()
                 },
-                &**out_xsqlda
+                &**out_xsqlda,
             ) != 0
             {
                 return Err(self.status.as_error(&self.ibase));
@@ -500,7 +499,8 @@ impl FirebirdClient for NativeFbClient {
         // Just to make sure the params are not dropped too soon
         drop(params);
 
-        let (_, col_buf) = self.stmt_data_map
+        let (_, col_buf) = self
+            .stmt_data_map
             .get(&stmt_handle)
             .ok_or_else(|| FbError::from("Tried to fetch a dropped statement"))?;
 

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -302,16 +302,16 @@ parse_functions! {
             arg5: *const XSQLDA,
         ) -> ISC_STATUS;
     }
-    // extern "C" {
-    //     pub fn isc_dsql_execute2(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: *mut isc_tr_handle,
-    //         arg3: *mut isc_stmt_handle,
-    //         arg4: ::std::os::raw::c_ushort,
-    //         arg5: *const XSQLDA,
-    //         arg6: *const XSQLDA,
-    //     ) -> ISC_STATUS;
-    // }
+    extern "C" {
+         pub fn isc_dsql_execute2(
+             arg1: *mut ISC_STATUS,
+             arg2: *mut isc_tr_handle,
+             arg3: *mut isc_stmt_handle,
+             arg4: ::std::os::raw::c_ushort,
+             arg5: *const XSQLDA,
+             arg6: *const XSQLDA,
+         ) -> ISC_STATUS;
+    }
     extern "C" {
         pub fn isc_dsql_execute_immediate(
             arg1: *mut ISC_STATUS,

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -210,7 +210,7 @@ impl FirebirdClient for RustFbClient {
         mut tr_handle: Self::TrHandle,
         mut stmt_handle: Self::StmtHandle,
         params: Vec<SqlType>,
-    ) -> Result<Vec<Vec<Column>>, FbError> {
+    ) -> Result<Vec<Column>, FbError> {
         todo!()
     }
 }

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -193,6 +193,19 @@ impl FirebirdClient for RustFbClient {
             .unwrap_or_else(err_client_not_connected)
     }
 
+    fn execute2(
+        &mut self,
+        _db_handle: Self::DbHandle,
+        tr_handle: Self::TrHandle,
+        stmt_handle: Self::StmtHandle,
+        params: Vec<SqlType>,
+    ) -> Result<Vec<Column>, FbError> {
+        self.conn
+            .as_mut()
+            .map(|conn| conn.execute2(tr_handle, stmt_handle, &params))
+            .unwrap_or_else(err_client_not_connected)
+    }
+
     fn fetch(
         &mut self,
         _db_handle: Self::DbHandle,
@@ -203,15 +216,6 @@ impl FirebirdClient for RustFbClient {
             .as_mut()
             .map(|conn| conn.fetch(tr_handle, stmt_handle))
             .unwrap_or_else(err_client_not_connected)
-    }
-    fn execute2(
-        &mut self,
-        mut db_handle: Self::DbHandle,
-        mut tr_handle: Self::TrHandle,
-        mut stmt_handle: Self::StmtHandle,
-        params: Vec<SqlType>,
-    ) -> Result<Vec<Column>, FbError> {
-        todo!()
     }
 }
 
@@ -549,6 +553,70 @@ impl FirebirdWireConnection {
             self.read_response()?;
 
             Ok(())
+        } else {
+            Err("Tried to execute a dropped statement".into())
+        }
+    }
+
+    /// Execute the prepared statement with parameters, returning data
+    pub fn execute2(
+        &mut self,
+        tr_handle: TrHandle,
+        stmt_handle: StmtHandle,
+        params: &[SqlType],
+    ) -> Result<Vec<Column>, FbError> {
+        let params =
+            if let Some(StmtData { param_count, .. }) = self.stmt_data_map.get_mut(&stmt_handle) {
+                if params.len() != *param_count {
+                    return Err(format!(
+                        "Tried to execute a statement that has {} parameters while providing {}",
+                        param_count,
+                        params.len()
+                    )
+                    .into());
+                }
+
+                blr::params_to_blr(self, tr_handle, params)?
+            } else {
+                return Err("Tried to execute a dropped statement".into());
+            };
+
+        if let Some(StmtData { blr, xsqlda, .. }) = self.stmt_data_map.get(&stmt_handle) {
+            self.socket
+                .write_all(&execute2(
+                    tr_handle.0,
+                    stmt_handle.0,
+                    &params.blr,
+                    &params.values,
+                    &blr,
+                ))
+                .unwrap();
+            self.socket.flush()?;
+
+            let (op_code, mut resp) = read_packet(&mut self.socket, &mut self.buff)?;
+
+            if op_code == WireOp::Response as u32 {
+                // An error ocurred
+                parse_response(&mut resp)?;
+            }
+
+            if op_code != WireOp::SqlResponse as u32 {
+                return err_conn_rejected(op_code);
+            }
+
+            dbg!(&resp);
+
+            let parsed_cols = parse_sql_response(&mut resp, xsqlda, self.version, &self.charset)?;
+
+            parse_response(&mut resp)?;
+
+            let mut cols = Vec::with_capacity(parsed_cols.len());
+
+            for pc in parsed_cols {
+                cols.push(pc.into_column(self, tr_handle)?);
+            }
+
+            Ok(cols)
         } else {
             Err("Tried to execute a dropped statement".into())
         }

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -601,9 +601,6 @@ impl FirebirdWireConnection {
             if op_code != WireOp::SqlResponse as u32 {
                 return err_conn_rejected(op_code);
             }
-
-            dbg!(&resp);
-
             let parsed_cols = parse_sql_response(&mut resp, xsqlda, self.version, &self.charset)?;
 
             parse_response(&mut resp)?;

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -204,6 +204,15 @@ impl FirebirdClient for RustFbClient {
             .map(|conn| conn.fetch(tr_handle, stmt_handle))
             .unwrap_or_else(err_client_not_connected)
     }
+    fn execute2(
+        &mut self,
+        mut db_handle: Self::DbHandle,
+        mut tr_handle: Self::TrHandle,
+        mut stmt_handle: Self::StmtHandle,
+        params: Vec<SqlType>,
+    ) -> Result<Vec<Vec<Column>>, FbError> {
+        todo!()
+    }
 }
 
 fn err_client_not_connected<T>() -> Result<T, FbError> {

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -485,7 +485,6 @@ pub fn parse_fetch_response(
     version: ProtocolVersion,
     charset: &Charset,
 ) -> Result<Option<Vec<ParsedColumn>>, FbError> {
-
     if resp.remaining() < 8 {
         return err_invalid_response();
     }
@@ -506,7 +505,6 @@ pub fn parse_sql_response(
     version: ProtocolVersion,
     charset: &Charset,
 ) -> Result<Vec<ParsedColumn>, FbError> {
-
     let has_row = resp.get_u32() != 0;
     if !has_row {
         return Err("Fetch returned no columns".into());

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -547,15 +547,15 @@ where
             .borrow_mut()
             .insert_and_close(self, stmt_cache_data)?;
 
-        println!("{:?}", res);
-        //let f_res = res?.iter()
-        //    .map(|row| FromRow::try_from(row.to_vec()).transpose())
-        //    .collect::<R>();
+        let mut f_res = vec![];
+
+        for row in res? {
+            f_res.push(FromRow::try_from(row)?);
+        }
 
         tr.commit()?;
 
-        todo!("mod conn")
-        //Ok(f_res)
+        Ok(f_res)
     }
 }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -529,15 +529,15 @@ where
     fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>
     where
         P: IntoParams,
-        R: FromRow + 'static
+        R: FromRow + 'static,
     {
         let mut tr = Transaction::new(self)?;
 
         // Get a statement from the cache
         let mut stmt_cache_data =
             self.stmt_cache
-            .borrow_mut()
-            .get_or_prepare(self, &mut tr.data, sql)?;
+                .borrow_mut()
+                .get_or_prepare(self, &mut tr.data, sql)?;
 
         // Do not return now in case of error, because we need to return the statement to the cache
         let res = stmt_cache_data.stmt.execute2(self, &mut tr.data, params);

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -526,7 +526,7 @@ where
         Ok(())
     }
 
-    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
+    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>
     where
         P: IntoParams,
         R: FromRow + 'static
@@ -547,11 +547,7 @@ where
             .borrow_mut()
             .insert_and_close(self, stmt_cache_data)?;
 
-        let mut f_res = vec![];
-
-        for row in res? {
-            f_res.push(FromRow::try_from(row)?);
-        }
+        let f_res = FromRow::try_from(res?)?;
 
         tr.commit()?;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -53,7 +53,7 @@ pub trait Execute {
         P: IntoParams;
 
     /// Execute a query that will return data,
-    /// like the 'insert ... returning ..' or 'execute block'
+    /// like the 'insert ... returning ..' or 'execute procedure'
     ///
     /// Use `()` for no parameters or a tuple of parameters
     fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,10 @@ use rsfbclient_core::{FbError, FromRow, IntoParams};
 
 /// Implemented for types that can be used to execute sql queries
 pub trait Queryable {
-    /// Returns the results of the query as an iterator
+    /// Returns the results of the query as an iterator.
+    ///
+    /// The query must be return an open cursor, so for cases like 'insert .. returning'
+    /// you will need to use the [execute_returnable](prelude/trait.Execute.html#tymethod.execute_returnable) method instead.
     ///
     /// Use `()` for no parameters or a tuple of parameters
     fn query_iter<'a, P, R>(
@@ -20,7 +23,10 @@ pub trait Queryable {
         P: IntoParams,
         R: FromRow + 'static;
 
-    /// Returns the results of the query as a `Vec`
+    /// Returns the results of the query as a `Vec`.
+    ///
+    /// The query must be return an open cursor, so for cases like 'insert .. returning'
+    /// you will need to use the [execute_returnable](prelude/trait.Execute.html#tymethod.execute_returnable) method instead.
     ///
     /// Use `()` for no parameters or a tuple of parameters
     fn query<'a, P, R>(&'a mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
@@ -31,7 +37,10 @@ pub trait Queryable {
         self.query_iter(sql, params)?.collect()
     }
 
-    /// Returns the first result of the query, or None
+    /// Returns the first result of the query, or None.
+    ///
+    /// The query must be return an open cursor, so for cases like 'insert .. returning'
+    /// you will need to use the [execute_returnable](prelude/trait.Execute.html#tymethod.execute_returnable) method instead.
     ///
     /// Use `()` for no parameters or a tuple of parameters
     fn query_first<'a, P, R>(&'a mut self, sql: &str, params: P) -> Result<Option<R>, FbError>
@@ -52,8 +61,11 @@ pub trait Execute {
     where
         P: IntoParams;
 
-    /// Execute a query that will return data,
-    /// like the 'insert ... returning ..' or 'execute procedure'
+    /// Execute a query that will return data, like the 'insert ... returning ..' or 'execute procedure'.
+    ///
+    /// This method is designated for use in cases when you don't have
+    /// a cursor to fetch. [This link](https://www.ibexpert.net/ibe/pmwiki.php?n=Doc.DataManipulationLanguage#EXECUTEBLOCKStatement)
+    /// explain the Firebird behavior for this cases.
     ///
     /// Use `()` for no parameters or a tuple of parameters
     fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>

--- a/src/query.rs
+++ b/src/query.rs
@@ -60,5 +60,4 @@ pub trait Execute {
     where
         P: IntoParams,
         R: FromRow + 'static;
-
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -51,4 +51,14 @@ pub trait Execute {
     fn execute<P>(&mut self, sql: &str, params: P) -> Result<(), FbError>
     where
         P: IntoParams;
+
+    /// Execute a query that will return data,
+    /// like the 'insert ... returning ..' or 'execute block'
+    ///
+    /// Use `()` for no parameters or a tuple of parameters
+    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
+    where
+        P: IntoParams,
+        R: FromRow + 'static;
+
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -56,7 +56,7 @@ pub trait Execute {
     /// like the 'insert ... returning ..' or 'execute procedure'
     ///
     /// Use `()` for no parameters or a tuple of parameters
-    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
+    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>
     where
         P: IntoParams,
         R: FromRow + 'static;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -169,6 +169,24 @@ where
         Ok(())
     }
 
+    /// Execute the current statement with input and output paramters
+    ///
+    /// Use `()` for no parameters or a tuple of parameters
+    pub fn execute2<T, C>(
+        &mut self,
+        conn: &Connection<C>,
+        tr: &mut TransactionData<C::TrHandle>,
+        params: T,
+    ) -> Result<Vec<Vec<Column>>, FbError>
+    where
+        T: IntoParams,
+        C: FirebirdClient<StmtHandle = H>,
+    {
+        conn.cli
+            .borrow_mut()
+            .execute2(conn.handle, tr.handle, self.handle, params.to_params())
+    }
+
     /// Execute the current statement
     /// and returns the column buffer
     ///

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -177,7 +177,7 @@ where
         conn: &Connection<C>,
         tr: &mut TransactionData<C::TrHandle>,
         params: T,
-    ) -> Result<Vec<Vec<Column>>, FbError>
+    ) -> Result<Vec<Column>, FbError>
     where
         T: IntoParams,
         C: FirebirdClient<StmtHandle = H>,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -191,7 +191,7 @@ where
         Ok(())
     }
 
-    /// Execute the current statement with input and output paramters
+    /// Execute the current statement with input and returns a single row
     ///
     /// Use `()` for no parameters or a tuple of parameters
     pub fn execute2<T, C>(

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -204,9 +204,12 @@ where
         T: IntoParams,
         C: FirebirdClient<StmtHandle = H>,
     {
-        conn.cli
-            .borrow_mut()
-            .execute2(conn.handle, tr.handle, self.handle, self.named_params.convert(params)?)
+        conn.cli.borrow_mut().execute2(
+            conn.handle,
+            tr.handle,
+            self.handle,
+            self.named_params.convert(params)?,
+        )
     }
 
     /// Execute the current statement

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -15,6 +15,14 @@ mk_tests_default! {
     fn execute_procedure() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 
+        let (engine_version,): (String,) = conn.query_first(
+            "SELECT rdb$get_context('SYSTEM', 'ENGINE_VERSION') from rdb$database;",
+            (),
+        )?.unwrap();
+        if engine_version.starts_with("2.") {
+            return Ok(());
+        }
+
         let ddl_procedure = "create or alter procedure get_value()
                                 returns (val int not null)
                                 as

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -18,9 +18,17 @@ mk_tests_default! {
         conn.execute("DROP TABLE RINSERT_RETURNING", ()).ok();
         conn.execute("CREATE TABLE RINSERT_RETURNING (id int, name varchar(10))", ())?;
 
-        let returning: Vec<(i32, String,)> = conn.execute_returnable("insert into rinsert_returning (id, name) values (10, 'abc 132') returning id, name", ())?;
+        let returning: (i32, String,) = conn.execute_returnable("insert into rinsert_returning (id, name) values (10, 'abc 132') returning id, name", ())?;
 
-        assert_eq!(vec![(10, "abc 132".to_string(),)], returning);
+        assert_eq!((10, "abc 132".to_string(),), returning);
+
+        conn.with_transaction(|tr| {
+            let id: (i32,) = tr.execute_returnable("insert into rinsert_returning (id) values (11) returning id", ())?;
+
+            assert_eq!((11,), id);
+
+            Ok(())
+        })?;
 
         Ok(())
     }

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -12,6 +12,20 @@ mk_tests_default! {
     use rand::{distributions::Standard, Rng};
 
     #[test]
+    fn insert_returing() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        conn.execute("DROP TABLE RINSERT_RETURNING", ()).ok();
+        conn.execute("CREATE TABLE RINSERT_RETURNING (id int)", ())?;
+
+        let ids: Vec<(i32,)> = conn.execute_returnable("insert into rinsert_returning (id) values (10) returning id", ())?;
+
+        //assert_eq!(Some((10,)), id);
+
+        Ok(())
+    }
+
+    #[test]
     fn boolean() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -12,6 +12,31 @@ mk_tests_default! {
     use rand::{distributions::Standard, Rng};
 
     #[test]
+    fn execute_procedure() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        let ddl_procedure = "create or alter procedure get_value()
+                                returns (val int not null)
+                                as
+                                begin
+                                    val = 150;
+                                    suspend;
+                                end;";
+        conn.execute(ddl_procedure, ())?;
+
+        // Using select
+        let (val,): (i32,) = conn.query_first("select p.val from get_value p", ())?
+            .unwrap();
+        assert_eq!(150, val);
+
+        // Using exec proc
+        let (val,): (i32,) = conn.execute_returnable("execute procedure get_value", ())?;
+        assert_eq!(150, val);
+
+        Ok(())
+    }
+
+    #[test]
     fn execute_block() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -12,7 +12,31 @@ mk_tests_default! {
     use rand::{distributions::Standard, Rng};
 
     #[test]
-    fn insert_returing() -> Result<(), FbError> {
+    fn execute_block() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        let sql = "execute block (x double precision = ?, y double precision = ?)
+                    returns (gmean double precision)
+                    as
+                    begin
+                        gmean = sqrt(x*y);
+                        suspend;
+                    end";
+
+        // with execute_returnable
+        let (sqrt,): (f64,) = conn.execute_returnable(sql, (10, 20))?;
+        assert_eq!(14.142135623730951, sqrt);
+
+        // with query
+        let (sqrt,): (f64,) = conn.query_first(sql, (10, 20))?
+            .unwrap();
+        assert_eq!(14.142135623730951, sqrt);
+
+        Ok(())
+    }
+
+    #[test]
+    fn insert_returning() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 
         conn.execute("DROP TABLE RINSERT_RETURNING", ()).ok();

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -45,6 +45,7 @@ mk_tests_default! {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn execute_block() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -16,11 +16,11 @@ mk_tests_default! {
         let mut conn = cbuilder().connect()?;
 
         conn.execute("DROP TABLE RINSERT_RETURNING", ()).ok();
-        conn.execute("CREATE TABLE RINSERT_RETURNING (id int)", ())?;
+        conn.execute("CREATE TABLE RINSERT_RETURNING (id int, name varchar(10))", ())?;
 
-        let ids: Vec<(i32,)> = conn.execute_returnable("insert into rinsert_returning (id) values (10) returning id", ())?;
+        let returning: Vec<(i32, String,)> = conn.execute_returnable("insert into rinsert_returning (id, name) values (10, 'abc 132') returning id, name", ())?;
 
-        //assert_eq!(Some((10,)), id);
+        assert_eq!(vec![(10, "abc 132".to_string(),)], returning);
 
         Ok(())
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -226,11 +226,12 @@ where
         let params = params.to_params();
 
         // Get a statement from the cache
-        let mut stmt_cache_data =
-            self.conn
-                .stmt_cache
-                .borrow_mut()
-                .get_or_prepare(self.conn, &mut self.data, sql, params.named(),)?;
+        let mut stmt_cache_data = self.conn.stmt_cache.borrow_mut().get_or_prepare(
+            self.conn,
+            &mut self.data,
+            sql,
+            params.named(),
+        )?;
 
         // Do not return now in case of error, because we need to return the statement to the cache
         let res = stmt_cache_data

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -221,14 +221,14 @@ where
     fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>
     where
         P: IntoParams,
-        R: FromRow + 'static
+        R: FromRow + 'static,
     {
         // Get a statement from the cache
         let mut stmt_cache_data =
             self.conn
-            .stmt_cache
-            .borrow_mut()
-            .get_or_prepare(self.conn, &mut self.data, sql)?;
+                .stmt_cache
+                .borrow_mut()
+                .get_or_prepare(self.conn, &mut self.data, sql)?;
 
         // Do not return now in case of error, because we need to return the statement to the cache
         let res = stmt_cache_data

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -217,6 +217,14 @@ where
 
         Ok(())
     }
+
+    fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
+    where
+        P: IntoParams,
+        R: FromRow + 'static
+    {
+        todo!("transaction")
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Started the support for 'insert .. returing' stmt and 'execute block'.

Now it's basically WIP code

---------

TODO:

- [x] 'insert .. returning' test
- [x] 'execute block' test
- [x] update docs
- [x] execute_returnable() in transaction
    - native
    - pure
- [x] execute_returnable() in connection
    - native
    - pure