### PR TITLE
doc and identifier modifications

### DIFF
--- a/rsfbclient-core/src/params.rs
+++ b/rsfbclient-core/src/params.rs
@@ -162,6 +162,8 @@ impl ParamsType {
 ///
 ///
 /// With both named (as a struct field) or positional (as a Vector or tuple element) parameters, `Option<T>`, with `T` an `IntoParam`,  may be used to indicate a nullable argument, wherein the `None` variant provides a `null` value.
+///
+/// This crate provides a [derive macro](prelude/derive.IntoParams.html) for supplying arguments via the fields of a struct and their labels.
 pub trait IntoParams {
     fn to_params(self) -> ParamsType;
 }

--- a/rsfbclient-core/src/params.rs
+++ b/rsfbclient-core/src/params.rs
@@ -140,7 +140,7 @@ pub enum ParamsType {
     /// Use of named parameters may currently give unexpected results. Please test your queries carefully
     /// when using this feature.
     ///
-    /// In particular, thie regex-based parser is known to definitely to have trouble with:
+    /// In particular, the simple regex-based parser is known to definitely to have trouble with:
     ///   * occurences of apostrophe (`'`) anywhere except as string literal delimiters (for example, in comments)
     ///   * statements with closed variable bindings (which uses the `:var` syntax) (for example, in PSQL via `EXECUTE BLOCK` or `EXECUTE PROCEDURE`)
     ///

--- a/rsfbclient-derive/src/lib.rs
+++ b/rsfbclient-derive/src/lib.rs
@@ -6,6 +6,13 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DataStruct, DeriveInput, Fields};
 
+/// Provide a [IntoParams<T>](../trait.IntoParams.html) implementation
+/// for structs.
+///
+/// All fields will be 'serialized' using his names and values. `Option<T>`
+/// fields with `None` values will be considered `null`.
+///
+/// The fields types must be implement the [IntoParam<T>](../trait.IntoParam.html) trait.
 #[proc_macro_derive(IntoParams)]
 pub fn into_params_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);

--- a/rsfbclient-derive/src/lib.rs
+++ b/rsfbclient-derive/src/lib.rs
@@ -6,13 +6,17 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DataStruct, DeriveInput, Fields};
 
-/// Provide a [IntoParams<T>](../trait.IntoParams.html) implementation
-/// for structs.
+/// Derive an [IntoParams<T>](../trait.IntoParams.html) implementation for structs.
 ///
-/// All fields will be 'serialized' using his names and values. `Option<T>`
-/// fields with `None` values will be considered `null`.
+/// This enables passing an instance of such a struct in places where named parameters
+/// are expected, using the field labels to associate field values with parameter names.
 ///
-/// The fields types must be implement the [IntoParam<T>](../trait.IntoParam.html) trait.
+/// The fields' types must implement the [IntoParam<T>](../trait.IntoParam.html) trait.
+///
+/// Note that `Option<T>` may be used as a field type to indicate a nullable parameter.
+///
+/// Providing an instance of the struct with value `None` for such a field corresponds to
+/// passing a `null` value for that field.
 #[proc_macro_derive(IntoParams)]
 pub fn into_params_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -856,7 +856,7 @@ fn connection_test() {
     println!("Statement type: {:?}", stmt_type);
 
     let params = match rsfbclient_core::IntoParams::to_params((1,)) {
-        rsfbclient_core::ParamsType::Unamed(params) => params,
+        rsfbclient_core::ParamsType::Positional(params) => params,
         _ => unreachable!(),
     };
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -450,9 +450,6 @@ impl<C> Queryable for Connection<C>
 where
     C: FirebirdClient,
 {
-    /// Prepare, execute, return the rows and commit the sql query
-    ///
-    /// Use `()` for no parameters or a tuple of parameters
     fn query_iter<'a, P, R>(
         &'a mut self,
         sql: &str,
@@ -497,9 +494,6 @@ impl<C> Execute for Connection<C>
 where
     C: FirebirdClient,
 {
-    /// Prepare, execute and commit the sql query
-    ///
-    /// Use `()` for no parameters or a tuple of parameters
     fn execute<P>(&mut self, sql: &str, params: P) -> Result<(), FbError>
     where
         P: IntoParams,

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,9 +8,16 @@ use rsfbclient_core::{FbError, FromRow, IntoParams};
 
 /// Implemented for types that can be used to execute sql queries
 pub trait Queryable {
-    /// Returns the results of the query as an iterator
+    /// Returns the results of the query as an iterator.
     ///
-    /// Use `()` for no parameters or a tuple of parameters
+    ///
+    /// possible values for argument `params`:
+    ///
+    /// `()`: no parameters,
+    ///
+    /// `(param0, param1, param2...)`: a tuple of `IntoParam` values corresponding to positional `?` sql parameters
+    ///
+    /// A struct for which `IntoParams` has been derived ([see there for details](prelude/derive.IntoParams.html))
     fn query_iter<'a, P, R>(
         &'a mut self,
         sql: &str,
@@ -22,7 +29,13 @@ pub trait Queryable {
 
     /// Returns the results of the query as a `Vec`
     ///
-    /// Use `()` for no parameters or a tuple of parameters
+    /// possible values for argument `params`:
+    ///
+    /// `()`: no parameters,
+    ///
+    /// `(param0, param1, param2...)`: a tuple of `IntoParam` values corresponding to positional `?` sql parameters
+    ///
+    /// A struct for which `IntoParams` has been derived ([see there for details](prelude/derive.IntoParams.html))
     fn query<'a, P, R>(&'a mut self, sql: &str, params: P) -> Result<Vec<R>, FbError>
     where
         P: IntoParams,
@@ -33,7 +46,13 @@ pub trait Queryable {
 
     /// Returns the first result of the query, or None
     ///
-    /// Use `()` for no parameters or a tuple of parameters
+    /// possible values for argument `params`:
+    ///
+    /// `()`: no parameters,
+    ///
+    /// `(param0, param1, param2...)`: a tuple of `IntoParam` values corresponding to positional `?` sql parameters
+    ///
+    /// A struct for which `IntoParams` has been derived ([see there for details](prelude/derive.IntoParams.html))
     fn query_first<'a, P, R>(&'a mut self, sql: &str, params: P) -> Result<Option<R>, FbError>
     where
         P: IntoParams,
@@ -47,7 +66,13 @@ pub trait Queryable {
 pub trait Execute {
     /// Execute a query, may or may not commit the changes
     ///
-    /// Use `()` for no parameters or a tuple of parameters
+    /// possible values for argument `params`:
+    ///
+    /// `()`: no parameters,
+    ///
+    /// `(param0, param1, param2...)`: a tuple of `IntoParam` values corresponding to positional `?` sql parameters
+    ///
+    /// A struct for which `IntoParams` has been derived ([see there for details](prelude/derive.IntoParams.html))
     fn execute<P>(&mut self, sql: &str, params: P) -> Result<(), FbError>
     where
         P: IntoParams;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -139,9 +139,6 @@ impl<'c, C> Queryable for Transaction<'c, C>
 where
     C: FirebirdClient,
 {
-    /// Prepare, execute and return the rows of the sql query
-    ///
-    /// Use `()` for no parameters or a tuple of parameters
     fn query_iter<'a, P, R>(
         &'a mut self,
         sql: &str,
@@ -191,9 +188,6 @@ impl<C> Execute for Transaction<'_, C>
 where
     C: FirebirdClient,
 {
-    /// Prepare and execute the sql query
-    ///
-    /// Use `()` for no parameters or a tuple of parameters
     fn execute<P>(&mut self, sql: &str, params: P) -> Result<(), FbError>
     where
         P: IntoParams,


### PR DESCRIPTION
Is what I said about `Option<T>` on `IntoParams` correct?

Please additionally add a doc comment for the derive macro, especially since it is referenced in `params.rs` and now `query.rs` docs.