### PR TITLE
add opt-out and opt-in options to ci using labels

### DIFF
--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -41,11 +41,8 @@ jobs:
       || ( (github.event.action != 'labeled') && contains( github.event.pull_request.labels.*.name, 'force-ci' ) )
       || (github.event.label.name == 'force-ci')
     steps:
-        #helpful for debugging event
-      - name: dump action context 'github'
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      - name: continue
+        run: echo not skipping CI. continuing now...
 
   linting:
     name: linting
@@ -85,9 +82,9 @@ jobs:
 
   testing:
     name: testing
-    needs: linting    
     strategy:
       fail-fast: false
+      needs: linting
       matrix:
         os: ["ubuntu-20.04", "windows-latest", "macos-latest"]
         firebird: [v3, v2, v4]

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -82,9 +82,9 @@ jobs:
 
   testing:
     name: testing
+    needs: linting
     strategy:
       fail-fast: false
-      needs: linting
       matrix:
         os: ["ubuntu-20.04", "windows-latest", "macos-latest"]
         firebird: [v3, v2, v4]

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -85,9 +85,9 @@ jobs:
 
   testing:
     name: testing
+    needs: linting    
     strategy:
       fail-fast: false
-      needs: linting
       matrix:
         os: ["ubuntu-20.04", "windows-latest", "macos-latest"]
         firebird: [v3, v2, v4]

--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -12,14 +12,45 @@
 #   - cargo tarpaulin does not work on macos
 #   - cargo test fails with linking on macos
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.github/workflows/**'
+  pull_request:
+    types: [opened,reopened,synchronize,ready_for_review,labeled]
 
 name: testing_changes
 
 jobs:
+  run-guard:
+    # other jobs depend on this one using 'needs: run-guard' to avoid running when it is skipped.
+    # it succeeds if any of the following conditions are met:
+    #   - it is not a pr-labeling event AND the pr is not labeled 'prevent-ci' AND it is not a draft pr
+    #   - it is not a pr-labeling event AND the pr is labeled 'force-ci'
+    #   - it is a pr-labeling event AND the label being added is 'force-ci'
+    #
+    # on success it dumps the action's 'github' context
+    runs-on: ubuntu-latest
+    name: 'run-guard'
+    if: |
+      (
+           (github.event.action != 'labeled')
+        && !contains( github.event.pull_request.labels.*.name, 'prevent-ci')
+        && !github.event.pull_request.draft
+      )
+      || ( (github.event.action != 'labeled') && contains( github.event.pull_request.labels.*.name, 'force-ci' ) )
+      || (github.event.label.name == 'force-ci')
+    steps:
+        #helpful for debugging event
+      - name: dump action context 'github'
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
   linting:
     name: linting
     runs-on: ubuntu-latest
+    needs: run-guard
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -56,6 +87,7 @@ jobs:
     name: testing
     strategy:
       fail-fast: false
+      needs: linting
       matrix:
         os: ["ubuntu-20.04", "windows-latest", "macos-latest"]
         firebird: [v3, v2, v4]
@@ -89,7 +121,6 @@ jobs:
           - build: pure_rust
             features: pure_rust date_time pool
     runs-on: "${{ matrix.os }}"
-    needs: linting
     steps:
       - name: Setup FirebirdSQL ${{ matrix.firebird }} with image  ${{ matrix.image }} on docker
         if: matrix.plataform == 'linux'


### PR DESCRIPTION
This will change the CI in a few ways.

1. doesn't run the CI on push with only workflow changes
2. checks if CI run needed when a draft PR becomes ready for review
3. checks if CI run needed when a label is added to a PR. in most cases this does not cause the CI to run but it does cause the workflow itself to run.
4. adds detection for draft status of PRs. By default the CI is skipped for draft PRs.
5. adds detection for label 'prevent-ci' on PRs (draft or not) to prevent running CI.
6. adds detection for label 'force-ci' which overrides all of the above and forces CI to be run on subsequent changes (excluding label additions)
7. force runs the CI once when the 'force-ci' label is added to a PR

note that *all* label additions trigger the workflow, but this configuration will only allow the CI to run if the added label is `force-ci`. This means if you add any label that isn't 'force-ci' it will change the ci checks to 'skipped' regardless of what they were before.
i think this is not a big deal, the old run results should still be available under 'actions' tab.
If we ever start using a lot of other labels on PRs this could start to get noisy. To change this might require some larger restructuring of the workflow

interestingly the changes seem to work within the context of this PR itself so you can test it here by adding and removing labels
and dummy edits if you want, but before merging we should be careful the about commit noise that would introduce

closes #76 