### PR TITLE
Removed some `unwrap` uses

### DIFF
--- a/rsfbclient-core/src/params.rs
+++ b/rsfbclient-core/src/params.rs
@@ -265,8 +265,7 @@ impl NamedParams {
         for params in rparams.captures_iter(raw_sql) {
             for param in params
                 .iter()
-                .filter(|p| p.is_some())
-                .map(|p| p.unwrap().as_str())
+                .filter_map(|p| p.map(|m| m.as_str()))
                 .filter(|p| p.starts_with(':'))
             {
                 params_names.push(param.replace(":", ""));

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -369,7 +369,9 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
         // Create the column buffers and set the xsqlda conercions
         let col_buffers = (0..xsqlda.sqld)
             .map(|col| {
-                let xcol = xsqlda.get_xsqlvar_mut(col as usize).unwrap();
+                let xcol = xsqlda
+                    .get_xsqlvar_mut(col as usize)
+                    .ok_or_else(|| FbError::from("Error getting the xsqlvar"))?;
 
                 ColumnBuffer::from_xsqlvar(xcol)
             })

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -52,7 +52,9 @@ impl Params {
             for (col, info) in infos.into_iter().enumerate() {
                 buffers.push(ParamBuffer::from_parameter(
                     info,
-                    xsqlda.get_xsqlvar_mut(col).unwrap(),
+                    xsqlda
+                        .get_xsqlvar_mut(col)
+                        .ok_or_else(|| FbError::from("Error getting the xsqlvar"))?,
                     db_handle,
                     tr_handle,
                     ibase,

--- a/rsfbclient-native/src/varchar.rs
+++ b/rsfbclient-native/src/varchar.rs
@@ -19,10 +19,12 @@ unsafe impl Send for Varchar {}
 impl Varchar {
     /// Allocate a new varchar buffer
     pub fn new(capacity: u16) -> Self {
-        let mut ptr = ptr::NonNull::new(unsafe {
+        let mut ptr = match ptr::NonNull::new(unsafe {
             alloc::alloc(layout(capacity as usize)) as *mut InnerVarchar
-        })
-        .unwrap();
+        }) {
+            Some(ptr) => ptr,
+            None => alloc::handle_alloc_error(layout(capacity as usize)),
+        };
 
         unsafe { ptr.as_mut().len = 0 };
 

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -390,9 +390,7 @@ impl FirebirdWireConnection {
     ) -> Result<TrHandle, FbError> {
         let tpb = [ibase::isc_tpb_version3 as u8, isolation_level as u8];
 
-        self.socket
-            .write_all(&transaction(db_handle.0, &tpb))
-            .unwrap();
+        self.socket.write_all(&transaction(db_handle.0, &tpb))?;
         self.socket.flush()?;
 
         let resp = self.read_response()?;
@@ -422,14 +420,12 @@ impl FirebirdWireConnection {
         dialect: Dialect,
         sql: &str,
     ) -> Result<(), FbError> {
-        self.socket
-            .write_all(&exec_immediate(
-                tr_handle.0,
-                dialect as u32,
-                sql,
-                &self.charset,
-            )?)
-            .unwrap();
+        self.socket.write_all(&exec_immediate(
+            tr_handle.0,
+            dialect as u32,
+            sql,
+            &self.charset,
+        )?)?;
         self.socket.flush()?;
 
         self.read_response()?;
@@ -545,14 +541,12 @@ impl FirebirdWireConnection {
 
         let params = blr::params_to_blr(self, tr_handle, params)?;
 
-        self.socket
-            .write_all(&execute(
-                tr_handle.0,
-                stmt_handle.handle.0,
-                &params.blr,
-                &params.values,
-            ))
-            .unwrap();
+        self.socket.write_all(&execute(
+            tr_handle.0,
+            stmt_handle.handle.0,
+            &params.blr,
+            &params.values,
+        ))?;
         self.socket.flush()?;
 
         self.read_response()?;
@@ -578,15 +572,13 @@ impl FirebirdWireConnection {
 
         let params = blr::params_to_blr(self, tr_handle, params)?;
 
-        self.socket
-            .write_all(&execute2(
-                tr_handle.0,
-                stmt_handle.handle.0,
-                &params.blr,
-                &params.values,
-                &stmt_handle.blr,
-            ))
-            .unwrap();
+        self.socket.write_all(&execute2(
+            tr_handle.0,
+            stmt_handle.handle.0,
+            &params.blr,
+            &params.values,
+            &stmt_handle.blr,
+        ))?;
         self.socket.flush()?;
 
         let (op_code, mut resp) = read_packet(&mut self.socket, &mut self.buff)?;

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -530,7 +530,8 @@ pub fn parse_sql_response(
     let read_null = |resp: &mut Bytes, i: usize| {
         if version >= ProtocolVersion::V13 {
             // read from the null bitmap
-            Ok::<_, FbError>((null_map.as_ref().unwrap()[i / 8] >> (i % 8)) & 1 != 0)
+            let null_map = null_map.as_ref().expect("Null map was not initialized");
+            Ok::<_, FbError>((null_map[i / 8] >> (i % 8)) & 1 != 0)
         } else {
             // read from the response
             Ok(resp.get_u32()? != 0)


### PR DESCRIPTION
The ones at `rsfbclient-rust/src/client.rs` are specially important, as they are not really that difficult to panic.
Don't know how i did not see them before.