### PR TITLE
ManuallyDrop droped

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,7 +4,7 @@
 //! Connection functions
 //!
 use rsfbclient_core::{Dialect, FbError, FirebirdClient, FirebirdClientDbOps, FromRow, IntoParams};
-use std::{marker, mem::ManuallyDrop};
+use std::{marker, mem};
 
 use crate::{query::Queryable, statement::StatementData, Execute, Transaction};
 use stmt_cache::{StmtCache, StmtCacheData};
@@ -108,7 +108,7 @@ impl<C: FirebirdClient> Connection<C> {
     /// Close the current connection.
     pub fn close(mut self) -> Result<(), FbError> {
         let res = self.cleanup_and_detach();
-        ManuallyDrop::new(self);
+        mem::forget(self);
         res
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,7 +6,7 @@
 
 use rsfbclient_core::{FbError, FirebirdClient, FromRow, IntoParams, TrIsolationLevel, TrOp};
 use std::marker;
-use std::mem::ManuallyDrop;
+use std::mem;
 
 use super::{connection::Connection, statement::Statement};
 use crate::{
@@ -35,7 +35,7 @@ impl<'c, C: FirebirdClient> Transaction<'c, C> {
         let result = self.data.commit(self.conn);
 
         if result.is_ok() {
-            ManuallyDrop::new(self);
+            mem::forget(self);
         } else {
             let _ = self.rollback();
         }
@@ -56,7 +56,7 @@ impl<'c, C: FirebirdClient> Transaction<'c, C> {
     /// Rollback the current transaction changes
     pub fn rollback(mut self) -> Result<(), FbError> {
         let result = self.data.rollback(self.conn);
-        ManuallyDrop::new(self);
+        mem::forget(self);
         result
     }
 


### PR DESCRIPTION
Utilization of `ManuallyDrop` replaced by `mem::forget` due the [new rust 1.48](https://doc.rust-lang.org/src/core/mem/manually_drop.rs.html#65) recommendation, avoiding warnings.

More info about this rust change in [f3024073f92b15d38b42241e65067f0ba796896c](https://github.com/rust-lang/rust/commit/f3024073f92b15d38b42241e65067f0ba796896c), on std lib rust.