### PR TITLE
Avoid running security audit on forked repos

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -7,6 +7,8 @@ on:
     # would run a command only on Mondays.
 jobs:
   audit:
+    # Avoid running security audit on forked repositories
+    if: ( github.ref == 'refs/heads/master' ) && ( github.repository == 'fernandobatels/rsfbclient' )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
This is a minor caveat from using a scheduled action for running the security audit.

This adds a condition for skipping the security audit action/workflow on forked GitHub repositories for avoiding polluting logs and notifications.