### PR TITLE
Unnecessary command removed from build.rs

### DIFF
--- a/rsfbclient-native/build.rs
+++ b/rsfbclient-native/build.rs
@@ -14,7 +14,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=PROFILE");
     println!("cargo:rerun-if-env-changed=TARGET");
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=src/tests/mod.rs");
 }
 
 fn search_on_environment_var() -> bool {


### PR DESCRIPTION
Removed a 'rerun-if' command from 'build.rs' of rsfbclient-
native. The command was forcing the rsfbclient and rsfbclient-native
always recompile, due to the non-existence of the tests folder on
rsfbclient-native.