### PR TITLE
create_database() support

### DIFF
--- a/examples/createdb.rs
+++ b/examples/createdb.rs
@@ -1,0 +1,43 @@
+//!
+//! Rust Firebird Client
+//!
+//! Example of database creation
+//!
+
+#![allow(unused_variables, unused_mut)]
+
+use rsfbclient::FbError;
+
+fn main() -> Result<(), FbError> {
+    #[cfg(feature = "linking")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_link()
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .create_database()?;
+
+    #[cfg(feature = "dynamic_loading")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_load("./fbclient.lib")
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .create_database()?;
+
+    #[cfg(feature = "pure_rust")]
+    let mut conn = rsfbclient::builder_pure_rust()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .create_database()?;
+
+    conn.close()?;
+
+    Ok(())
+}

--- a/examples/createdb.rs
+++ b/examples/createdb.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), FbError> {
         .db_name("examples.fdb")
         .user("SYSDBA")
         .pass("masterkey")
+        .page_size(8 * 1024) // Optional
         .create_database()?;
 
     #[cfg(feature = "dynamic_loading")]
@@ -27,6 +28,7 @@ fn main() -> Result<(), FbError> {
         .db_name("examples.fdb")
         .user("SYSDBA")
         .pass("masterkey")
+        .page_size(16 * 1024) // Optional
         .create_database()?;
 
     #[cfg(feature = "pure_rust")]
@@ -35,6 +37,7 @@ fn main() -> Result<(), FbError> {
         .db_name("examples.fdb")
         .user("SYSDBA")
         .pass("masterkey")
+        .page_size(16 * 1024) // Optional
         .create_database()?;
 
     conn.close()?;

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -43,6 +43,13 @@ pub trait FirebirdClientDbOps: Send {
 
     /// Drop the database
     fn drop_database(&mut self, db_handle: &mut Self::DbHandle) -> Result<(), FbError>;
+
+    /// Create the database and attach
+    /// Returns a database handle on success
+    fn create_database(
+        &mut self,
+        config: &Self::AttachmentConfig,
+    ) -> Result<Self::DbHandle, FbError>;
 }
 
 ///Responsible for actual transaction and statement execution

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -49,6 +49,7 @@ pub trait FirebirdClientDbOps: Send {
     fn create_database(
         &mut self,
         config: &Self::AttachmentConfig,
+        page_size: Option<u32>,
     ) -> Result<Self::DbHandle, FbError>;
 }
 

--- a/rsfbclient-diesel/src/tests/types.rs
+++ b/rsfbclient-diesel/src/tests/types.rs
@@ -130,6 +130,7 @@ fn types2() -> Result<(), String> {
 }
 
 #[test]
+#[allow(clippy::bool_assert_comparison)]
 fn boolean() -> Result<(), String> {
     let conn = FbConnection::establish("firebird://SYSDBA:masterkey@localhost/test.fdb")
         .map_err(|e| e.to_string())?;

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -164,7 +164,7 @@ impl<T: LinkageMarker> FirebirdClientDbOps for NativeFbClient<T> {
         let mut handle = 0;
 
         if let Some(ps) = page_size {
-            dpb.extend(&[ibase::isc_dpb_page_size as u8, 4 as u8]);
+            dpb.extend(&[ibase::isc_dpb_page_size as u8, 4]);
             dpb.write_u32::<LittleEndian>(ps)?;
         }
 
@@ -176,7 +176,7 @@ impl<T: LinkageMarker> FirebirdClientDbOps for NativeFbClient<T> {
                 &mut handle,
                 dpb.len() as i16,
                 dpb.as_ptr() as *const _,
-                0 as i16,
+                0,
             ) != 0
             {
                 return Err(self.status.as_error(&self.ibase));

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -265,17 +265,17 @@ parse_functions! {
     //         arg7: *const ISC_SCHAR,
     //     ) -> ISC_STATUS;
     // }
-    // extern "C" {
-    //     pub fn isc_create_database(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: ::std::os::raw::c_short,
-    //         arg3: *const ISC_SCHAR,
-    //         arg4: *mut isc_db_handle,
-    //         arg5: ::std::os::raw::c_short,
-    //         arg6: *const ISC_SCHAR,
-    //         arg7: ::std::os::raw::c_short,
-    //     ) -> ISC_STATUS;
-    // }
+    extern "C" {
+        pub fn isc_create_database(
+           arg1: *mut ISC_STATUS,
+           arg2: ::std::os::raw::c_short,
+           arg3: *const ISC_SCHAR,
+           arg4: *mut isc_db_handle,
+           arg5: ::std::os::raw::c_short,
+           arg6: *const ISC_SCHAR,
+           arg7: ::std::os::raw::c_short,
+        ) -> ISC_STATUS;
+    }
     // extern "C" {
     //     pub fn isc_database_info(
     //         arg1: *mut ISC_STATUS,

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -58,7 +58,7 @@ impl Params {
                     db_handle,
                     tr_handle,
                     ibase,
-                    &charset,
+                    charset,
                 )?);
             }
 

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -177,7 +177,7 @@ impl ColumnBuffer {
 
             Timestamp(ts) => SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(**ts)),
 
-            BlobText(b) => SqlType::Text(blobtext_to_string(**b, db, tr, ibase, &charset)?),
+            BlobText(b) => SqlType::Text(blobtext_to_string(**b, db, tr, ibase, charset)?),
 
             BlobBinary(b) => SqlType::Binary(blobbinary_to_vec(**b, db, tr, ibase)?),
 

--- a/rsfbclient-rust/src/blr.rs
+++ b/rsfbclient-rust/src/blr.rs
@@ -44,7 +44,7 @@ pub fn params_to_blr(
                            data: &[u8]| {
         let (blob_handle, id) = conn.create_blob(tr_handle)?;
 
-        conn.put_segments(blob_handle, &data)?;
+        conn.put_segments(blob_handle, data)?;
 
         conn.close_blob(blob_handle)?;
 
@@ -75,7 +75,7 @@ pub fn params_to_blr(
                 }
             }
 
-            SqlType::Binary(data) => handle_blob(conn, &mut blr, &mut values, &data)?,
+            SqlType::Binary(data) => handle_blob(conn, &mut blr, &mut values, data)?,
 
             SqlType::Integer(i) => {
                 blr.put_slice(&[

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -351,7 +351,7 @@ impl FirebirdWireConnection {
                             // in the initial connection
 
                             socket.write_all(&cont_auth(
-                                &hex::encode(srp.get_a_pub()).as_bytes(),
+                                hex::encode(srp.get_a_pub()).as_bytes(),
                                 plugin,
                                 AuthPluginType::plugin_list(),
                                 &[],
@@ -925,7 +925,7 @@ where
 
     // Send proof data
     socket.write_all(&cont_auth(
-        &proof.as_bytes(),
+        proof.as_bytes(),
         plugin,
         AuthPluginType::plugin_list(),
         &[],

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -132,6 +132,7 @@ impl FirebirdClientDbOps for RustFbClient {
     fn create_database(
         &mut self,
         config: &Self::AttachmentConfig,
+        page_size: Option<u32>,
     ) -> Result<RustDbHandle, FbError> {
         let host = config.host.as_str();
         let port = config.port;
@@ -152,7 +153,7 @@ impl FirebirdClientDbOps for RustFbClient {
             )?,
         };
 
-        let attach_result = conn.create_database(db_name, user, pass);
+        let attach_result = conn.create_database(db_name, user, pass, page_size);
 
         // Put the connection back
         self.conn.replace(conn);
@@ -382,6 +383,7 @@ impl FirebirdWireConnection {
         db_name: &str,
         user: &str,
         pass: &str,
+        page_size: Option<u32>,
     ) -> Result<DbHandle, FbError> {
         self.socket.write_all(&create(
             db_name,
@@ -389,6 +391,7 @@ impl FirebirdWireConnection {
             pass,
             self.version,
             self.charset.clone(),
+            page_size,
         ))?;
         self.socket.flush()?;
 

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -128,6 +128,37 @@ impl FirebirdClientDbOps for RustFbClient {
             .map(|conn| conn.drop_database(db_handle))
             .unwrap_or_else(err_client_not_connected)
     }
+
+    fn create_database(
+        &mut self,
+        config: &Self::AttachmentConfig,
+    ) -> Result<RustDbHandle, FbError> {
+        let host = config.host.as_str();
+        let port = config.port;
+        let db_name = config.db_name.as_str();
+        let user = config.user.as_str();
+        let pass = config.pass.as_str();
+
+        // Take the existing connection, or connects
+        let mut conn = match self.conn.take() {
+            Some(conn) => conn,
+            None => FirebirdWireConnection::connect(
+                host,
+                port,
+                db_name,
+                user,
+                pass,
+                self.charset.clone(),
+            )?,
+        };
+
+        let attach_result = conn.create_database(db_name, user, pass);
+
+        // Put the connection back
+        self.conn.replace(conn);
+
+        attach_result
+    }
 }
 
 impl FirebirdClientSqlOps for RustFbClient {
@@ -262,7 +293,7 @@ impl FirebirdWireConnection {
         // Random key for the srp
         let srp_key: [u8; 32] = rand::random();
 
-        let req = connect(db_name, false, user, &username, &hostname, &srp_key);
+        let req = connect(db_name, user, &username, &hostname, &srp_key);
         socket.write_all(&req)?;
         socket.flush()?;
 
@@ -343,6 +374,27 @@ impl FirebirdWireConnection {
             lazy_count: 0,
             charset,
         })
+    }
+
+    /// Create the database and attach, returning a database handle
+    pub fn create_database(
+        &mut self,
+        db_name: &str,
+        user: &str,
+        pass: &str,
+    ) -> Result<DbHandle, FbError> {
+        self.socket.write_all(&create(
+            db_name,
+            user,
+            pass,
+            self.version,
+            self.charset.clone(),
+        ))?;
+        self.socket.flush()?;
+
+        let resp = self.read_response()?;
+
+        Ok(DbHandle(resp.handle))
     }
 
     /// Connect to a database, returning a database handle

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -139,7 +139,7 @@ pub fn attach(
     protocol: ProtocolVersion,
     charset: Charset,
 ) -> Bytes {
-    let dpb = build_dpb(user, pass, protocol, charset);
+    let dpb = build_dpb(user, pass, protocol, charset, None);
 
     let mut attach = BytesMut::with_capacity(16 + db_name.len() + dpb.len());
 
@@ -160,8 +160,9 @@ pub fn create(
     pass: &str,
     protocol: ProtocolVersion,
     charset: Charset,
+    page_size: Option<u32>,
 ) -> Bytes {
-    let dpb = build_dpb(user, pass, protocol, charset);
+    let dpb = build_dpb(user, pass, protocol, charset, page_size);
 
     let mut create = BytesMut::with_capacity(16 + db_name.len() + dpb.len());
 
@@ -176,10 +177,21 @@ pub fn create(
 }
 
 /// Dpb builder
-fn build_dpb(user: &str, pass: &str, protocol: ProtocolVersion, charset: Charset) -> Bytes {
+fn build_dpb(
+    user: &str,
+    pass: &str,
+    protocol: ProtocolVersion,
+    charset: Charset,
+    page_size: Option<u32>,
+) -> Bytes {
     let mut dpb = BytesMut::with_capacity(64);
 
     dpb.put_u8(1); //Version
+
+    if let Some(ps) = page_size {
+        dpb.put_slice(&[ibase::isc_dpb_page_size as u8, 4 as u8]);
+        dpb.put_u32(ps);
+    }
 
     let charset = charset.on_firebird.as_bytes();
 

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -189,7 +189,7 @@ fn build_dpb(
     dpb.put_u8(1); //Version
 
     if let Some(ps) = page_size {
-        dpb.put_slice(&[ibase::isc_dpb_page_size as u8, 4 as u8]);
+        dpb.put_slice(&[ibase::isc_dpb_page_size as u8, 4]);
         dpb.put_u32(ps);
     }
 
@@ -788,7 +788,7 @@ pub fn parse_status_vector(resp: &mut Bytes) -> Result<(), FbError> {
                 let msg = std::str::from_utf8(&msg[..]).unwrap_or("**Invalid message**");
 
                 num_arg += 1;
-                message = message.replace(&format!("@{}", num_arg), &msg);
+                message = message.replace(&format!("@{}", num_arg), msg);
             }
 
             // Aditional error message string

--- a/src/connection/builders/builder_native.rs
+++ b/src/connection/builders/builder_native.rs
@@ -140,9 +140,14 @@ where
     A: LinkageMarker,
     Self: FirebirdClientFactory<C = NativeFbClient<A>>,
 {
-    /// Create a new connection from the fully-built builder
+    /// Start a new connection from the fully-built builder
     pub fn connect(&self) -> Result<Connection<NativeFbClient<A>>, FbError> {
         Connection::open(self.new_instance()?, &self.conn_conf)
+    }
+
+    /// Create the database and start new connection from the fully-built builder
+    pub fn create_database(&self) -> Result<Connection<NativeFbClient<A>>, FbError> {
+        Connection::create_database(self.new_instance()?, &self.conn_conf)
     }
 }
 

--- a/src/connection/builders/builder_native.rs
+++ b/src/connection/builders/builder_native.rs
@@ -67,6 +67,7 @@ pub struct NativeConnectionBuilder<LinkageType, ConnectionType> {
 
     charset: Charset,
     lib_path: Option<String>,
+    page_size: Option<u32>,
 }
 
 impl<A, B> From<&NativeConnectionBuilder<A, B>>
@@ -147,7 +148,7 @@ where
 
     /// Create the database and start new connection from the fully-built builder
     pub fn create_database(&self) -> Result<Connection<NativeFbClient<A>>, FbError> {
-        Connection::create_database(self.new_instance()?, &self.conn_conf)
+        Connection::create_database(self.new_instance()?, &self.conn_conf, self.page_size)
     }
 }
 
@@ -185,6 +186,12 @@ where
         self.conn_conf.stmt_cache_size = stmt_cache_size;
         self
     }
+
+    /// Database page size. Used on db creation. Default: depends on firebird version
+    pub fn page_size(&mut self, size: u32) -> &mut Self {
+        self.page_size = Some(size);
+        self
+    }
 }
 
 impl<A, B> NativeConnectionBuilder<A, B> {
@@ -196,6 +203,7 @@ impl<A, B> NativeConnectionBuilder<A, B> {
             conn_conf: self.conn_conf,
             charset: self.charset,
             lib_path: self.lib_path,
+            page_size: self.page_size,
         }
     }
 }
@@ -208,6 +216,7 @@ impl Default for NativeConnectionBuilder<LinkageNotConfigured, ConnTypeNotConfig
             conn_conf: Default::default(),
             charset: charset::UTF_8,
             lib_path: None,
+            page_size: None,
         };
 
         self_result.conn_conf.dialect = Dialect::D3;

--- a/src/connection/builders/builder_pure_rust.rs
+++ b/src/connection/builders/builder_pure_rust.rs
@@ -39,6 +39,10 @@ impl PureRustConnectionBuilder {
         Connection::open(self.new_instance()?, &self.0)
     }
 
+    pub fn create_database(&self) -> Result<Connection<RustFbClient>, FbError> {
+        Connection::create_database(self.new_instance()?, &self.0)
+    }
+
     /// Username. Default: SYSDBA
     pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
         self.0.attachment_conf.user = user.into();

--- a/src/connection/builders/builder_pure_rust.rs
+++ b/src/connection/builders/builder_pure_rust.rs
@@ -21,6 +21,7 @@ impl FirebirdClientFactory for PureRustConnectionBuilder {
 pub struct PureRustConnectionBuilder(
     ConnectionConfiguration<RustFbClientAttachmentConfig>,
     Charset,
+    Option<u32>,
 );
 
 impl From<&PureRustConnectionBuilder> for ConnectionConfiguration<RustFbClientAttachmentConfig> {
@@ -40,7 +41,7 @@ impl PureRustConnectionBuilder {
     }
 
     pub fn create_database(&self) -> Result<Connection<RustFbClient>, FbError> {
-        Connection::create_database(self.new_instance()?, &self.0)
+        Connection::create_database(self.new_instance()?, &self.0, self.2)
     }
 
     /// Username. Default: SYSDBA
@@ -88,6 +89,12 @@ impl PureRustConnectionBuilder {
     /// Connection charset. Default: UTF-8
     pub fn charset(&mut self, charset: Charset) -> &mut Self {
         self.1 = charset;
+        self
+    }
+
+    /// Database page size. Used on db creation. Default: depends on firebird version
+    pub fn page_size(&mut self, size: u32) -> &mut Self {
+        self.2 = Some(size);
         self
     }
 
@@ -140,7 +147,8 @@ impl Default for PureRustConnectionBuilder {
     fn default() -> Self {
         let conn_conf = Default::default();
         let charset = charset::UTF_8;
-        let mut result = Self(conn_conf, charset);
+        let page_size = None;
+        let mut result = Self(conn_conf, charset, page_size);
 
         result
             .host("localhost")

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -112,6 +112,24 @@ impl<C: FirebirdClient> Connection<C> {
         })
     }
 
+    /// Create the database and start the client connection.
+    pub fn create_database(
+        mut cli: C,
+        conf: &ConnectionConfiguration<C::AttachmentConfig>,
+    ) -> Result<Connection<C>, FbError> {
+        let handle = cli.create_database(&conf.attachment_conf)?;
+        let stmt_cache = StmtCache::new(conf.stmt_cache_size);
+
+        Ok(Connection {
+            handle,
+            dialect: conf.dialect,
+            stmt_cache,
+            def_tr: None,
+            in_transaction: false,
+            cli,
+        })
+    }
+
     /// Drop the current database
     pub fn drop_database(mut self) -> Result<(), FbError> {
         self.cli.drop_database(&mut self.handle)?;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -116,8 +116,9 @@ impl<C: FirebirdClient> Connection<C> {
     pub fn create_database(
         mut cli: C,
         conf: &ConnectionConfiguration<C::AttachmentConfig>,
+        page_size: Option<u32>,
     ) -> Result<Connection<C>, FbError> {
-        let handle = cli.create_database(&conf.attachment_conf)?;
+        let handle = cli.create_database(&conf.attachment_conf, page_size)?;
         let stmt_cache = StmtCache::new(conf.stmt_cache_size);
 
         Ok(Connection {

--- a/src/tests/database.rs
+++ b/src/tests/database.rs
@@ -55,7 +55,7 @@ mk_tests_default! {
         let conn = builder_native()
             .with_dyn_load(libfbclient)
             .with_remote()
-            .db_name("test_create_db12.fdb")
+            .db_name("test_create_db2.fdb")
             .user("SYSDBA")
             .host("localhost")
             .create_database()?;
@@ -110,7 +110,28 @@ mk_tests_default! {
         let conn = builder_native()
             .with_dyn_load(libfbclient)
             .with_embedded()
-            .db_name("/tmp/embedded_test_create_db12.fdb")
+            .db_name("/tmp/embedded_test_create_db22.fdb")
+            .user("SYSDBA")
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "pure_rust", not(feature = "native_client")))]
+    fn pure_rust() -> Result<(), FbError> {
+        let conn = builder_pure_rust()
+            .from_string(
+                "firebird://localhost:3050/test_create_db3.fdb",
+            )?
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        let conn = builder_pure_rust()
+            .db_name("test_create_db33.fdb")
             .user("SYSDBA")
             .create_database()?;
 

--- a/src/tests/database.rs
+++ b/src/tests/database.rs
@@ -1,0 +1,121 @@
+//!
+//! Rust Firebird Client
+//!
+//! Database(create and drop) tests
+//!
+
+mk_tests_default! {
+    #[allow(unused_imports)]
+    use crate::*;
+
+    #[test]
+    #[cfg(all(feature = "linking", not(feature = "embedded_tests"), not(feature = "pure_rust")))]
+    fn dyn_linking() -> Result<(), FbError> {
+
+        let conn = builder_native()
+            .from_string(
+                "firebird://localhost:3050/test_create_db1.fdb",
+            )?
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        let conn = builder_native()
+            .with_dyn_link()
+            .with_remote()
+            .db_name("test_create_db11.fdb")
+            .user("SYSDBA")
+            .host("localhost")
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "dynamic_loading", not(feature = "embedded_tests"), not(feature = "pure_rust")))]
+    fn dyn_load() -> Result<(), FbError> {
+
+        #[cfg(target_os = "linux")]
+        let libfbclient = "libfbclient.so";
+        #[cfg(target_os = "windows")]
+        let libfbclient = "fbclient.dll";
+        #[cfg(target_os = "macos")]
+        let libfbclient = "libfbclient.dylib";
+
+        let conn = builder_native()
+            .from_string(
+                &format!("firebird://localhost:3050/test_create_db2.fdb?lib={}", libfbclient),
+            )?
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        let conn = builder_native()
+            .with_dyn_load(libfbclient)
+            .with_remote()
+            .db_name("test_create_db12.fdb")
+            .user("SYSDBA")
+            .host("localhost")
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "linking", feature = "embedded_tests", not(feature = "dynamic_loading"), not(feature = "pure_rust")))]
+    fn dyn_linking_embedded() -> Result<(), FbError> {
+        let conn = builder_native()
+            .from_string(
+                "firebird:///tmp/embedded_test_create_db1.fdb?dialect=3",
+            )?
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        let conn = builder_native()
+            .with_dyn_link()
+            .with_embedded()
+            .db_name("/tmp/embedded_test_create_db11.fdb")
+            .user("SYSDBA")
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "dynamic_loading", feature = "embedded_tests", not(feature = "linking"), not(feature = "pure_rust")))]
+    fn dyn_load_embedded() -> Result<(), FbError> {
+
+        #[cfg(target_os = "linux")]
+        let libfbclient = "libfbclient.so";
+        #[cfg(target_os = "windows")]
+        let libfbclient = "fbclient.dll";
+        #[cfg(target_os = "macos")]
+        let libfbclient = "libfbclient.dylib";
+
+        let conn = builder_native()
+            .from_string(
+                &format!("firebird:///tmp/embedded_test_create_db2.fdb?dialect=3&lib={}", libfbclient),
+            )?
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        let conn = builder_native()
+            .with_dyn_load(libfbclient)
+            .with_embedded()
+            .db_name("/tmp/embedded_test_create_db12.fdb")
+            .user("SYSDBA")
+            .create_database()?;
+
+        conn.drop_database()?;
+
+        Ok(())
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -114,6 +114,7 @@ macro_rules! mk_tests_default {
 
 mod charset;
 mod connection;
+mod database;
 mod params;
 mod row;
 mod transaction;

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -110,6 +110,7 @@ mk_tests_default! {
     }
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn boolean() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 


### PR DESCRIPTION
Add support for `create_database()` method, aka `isc_create_database`:
- native
  - [x] basic
  - [x] add page size parameter  
  - [x] update doc
- pure rust
  - [x] basic
  - [x] add page size parameter
  - [x] update doc