### PR TITLE
IntoParams derive fixed

### DIFF
--- a/examples/insert.rs
+++ b/examples/insert.rs
@@ -21,6 +21,12 @@ struct ParamTest {
     colc: String,
 }
 
+#[derive(Clone, IntoParams)]
+struct ParamTest2 {
+    colb: f32,
+    colc: String,
+}
+
 fn main() -> Result<(), FbError> {
     #[cfg(feature = "linking")]
     let mut conn = rsfbclient::builder_native()
@@ -58,11 +64,16 @@ fn main() -> Result<(), FbError> {
         colb: 132.0,
         colc: "Arroz".to_string(),
     };
+    let p3 = ParamTest2 {
+        colb: 150.0,
+        colc: "Feijão".to_string(),
+    };
 
     conn.with_transaction(|tr| {
         // First alternative (Recommended) (Prepares if needed and executes automatically)
         tr.execute(SQL_INSERT, (94, "Banana"))?; // with position params
         tr.execute(SQL_INSERT_NAMED, p1.clone())?; // with named params
+        tr.execute(SQL_INSERT_NAMED, p3.clone())?; // with named params, again
 
         // Second alternative
         tr.execute_immediate(SQL_INSERT_PURE)?;
@@ -76,10 +87,11 @@ fn main() -> Result<(), FbError> {
         }
         // Fourth alternative, with named params
         {
-            let mut stmt = tr.prepare(SQL_INSERT_NAMED, false)?;
+            let mut stmt = tr.prepare(SQL_INSERT_NAMED, true)?;
 
             stmt.execute(p1.clone())?;
             stmt.execute(p2.clone())?;
+            stmt.execute(p3.clone())?;
         }
 
         Ok(())

--- a/rsfbclient-derive/src/lib.rs
+++ b/rsfbclient-derive/src/lib.rs
@@ -38,11 +38,11 @@ pub fn into_params_derive(input: TokenStream) -> TokenStream {
         });
 
     let st_impl = quote! {
-        use rsfbclient::{IntoParams, IntoParam, ParamsType};
-        use std::collections::HashMap;
+        impl rsfbclient::IntoParams for #st_name {
+            fn to_params(self) -> rsfbclient::ParamsType {
+                use std::collections::HashMap;
+                use rsfbclient::{IntoParams, IntoParam, ParamsType};
 
-        impl IntoParams for #st_name {
-            fn to_params(self) -> ParamsType {
                 let mut params = HashMap::new();
 
                 #(params.insert(#st_fields_params));*;

--- a/src/tests/params.rs
+++ b/src/tests/params.rs
@@ -149,6 +149,43 @@ mk_tests_default! {
     }
 
     #[test]
+    fn multi_struct_namedparams() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        #[derive(Clone, IntoParams)]
+        struct ParamTest1 {
+            pub num: i32,
+        }
+
+        let ptest1 = ParamTest1 {
+            num: 10,
+        };
+
+        let res1: Option<(i32,)> = conn.query_first(
+            "select 1 from rdb$database where 10 = :num ",
+            ptest1.clone(),
+        )?;
+        assert!(res1.is_some());
+
+        #[derive(Clone, IntoParams)]
+        struct ParamTest2 {
+            pub num: i32,
+        }
+
+        let ptest2 = ParamTest2 {
+            num: 10,
+        };
+
+        let res2: Option<(i32,)> = conn.query_first(
+            "select 1 from rdb$database where 10 = :num ",
+            ptest2.clone(),
+        )?;
+        assert!(res2.is_some());
+
+        Ok(())
+    }
+
+    #[test]
     fn boolean() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 


### PR DESCRIPTION
Automatic implementation of IntoParams using derive changed to avoid using the 'use' keyword.

Without this, we cannot use the derive in more than one struct in the same module, due to the multiple imports.

New test created and example fixed. #123