### PR TITLE
Firebird events support

### DIFF
--- a/.github/workflows/testing_changes.yml
+++ b/.github/workflows/testing_changes.yml
@@ -250,7 +250,7 @@ jobs:
         if: matrix.plataform == 'linux'
         # TODO: #[error]The process 'C:\Rust\.cargo\bin\cargo.exe' failed with exit code 101: error: no such subcommand: `tarpaulin`
         with:
-          version: "latest"
+          version: "0.22.0"
           run-types: "AllTargets"
           out-type: "Lcov"
           args: -v --line --count --branch --no-default-features --features '${{ matrix.features }}' -- --test-threads 1
@@ -271,7 +271,7 @@ jobs:
         if: matrix.plataform == 'linux'
         # TODO: #[error]The process 'C:\Rust\.cargo\bin\cargo.exe' failed with exit code 101: error: no such subcommand: `tarpaulin`
         with:
-          version: "latest"
+          version: "0.22.0"
           run-types: "AllTargets"
           out-type: "Lcov"
           args: -v --line --count --branch -p rsfbclient-rust
@@ -292,7 +292,7 @@ jobs:
         if: matrix.plataform == 'linux'
         # TODO: #[error]The process 'C:\Rust\.cargo\bin\cargo.exe' failed with exit code 101: error: no such subcommand: `tarpaulin`
         with:
-          version: "latest"
+          version: "0.22.0"
           run-types: "AllTargets"
           out-type: "Lcov"
           args: -v --line --count --branch --manifest-path rsfbclient-diesel/Cargo.toml --no-default-features --features '${{ matrix.features_diesel }}' -- --test-threads 1

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,53 @@
+//!
+//! Rust Firebird Client
+//!
+//! Examples of events traits
+//!
+
+#![allow(unused_variables, unused_mut)]
+
+use rsfbclient::{FbError, RemoteEventsManager, Queryable};
+
+fn main() -> Result<(), FbError> {
+    #[cfg(feature = "linking")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_link()
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
+
+    #[cfg(feature = "dynamic_loading")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_load("./fbclient.lib")
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
+
+    let wt = conn.listen_event("ping".to_string(), move |c| {
+
+        println!("Pong! Some rows here:");
+
+        let rows: Vec<(String, String)> = c.query(
+            "select mon$attachment_name, mon$user from mon$attachments",
+            (),
+        )?;
+
+        for row in rows {
+            println!("Attachment {}, user {}", row.0, row.1);
+        }
+
+        return Ok(true);
+    })?;
+
+    println!("Try ping here with \"POST_EVENT 'ping'\"");
+
+    wt.join().unwrap()?;
+
+    Ok(())
+}

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -9,44 +9,47 @@
 use rsfbclient::{FbError, Queryable, RemoteEventsManager};
 
 fn main() -> Result<(), FbError> {
-    #[cfg(feature = "linking")]
-    let mut conn = rsfbclient::builder_native()
-        .with_dyn_link()
-        .with_remote()
-        .host("localhost")
-        .db_name("examples.fdb")
-        .user("SYSDBA")
-        .pass("masterkey")
-        .connect()?;
+    #[cfg(not(feature = "pure_rust"))] // No support for events with pure rust driver
+    {
+        #[cfg(feature = "linking")]
+        let mut conn = rsfbclient::builder_native()
+            .with_dyn_link()
+            .with_remote()
+            .host("localhost")
+            .db_name("examples.fdb")
+            .user("SYSDBA")
+            .pass("masterkey")
+            .connect()?;
 
-    #[cfg(feature = "dynamic_loading")]
-    let mut conn = rsfbclient::builder_native()
-        .with_dyn_load("./fbclient.lib")
-        .with_remote()
-        .host("localhost")
-        .db_name("examples.fdb")
-        .user("SYSDBA")
-        .pass("masterkey")
-        .connect()?;
+        #[cfg(feature = "dynamic_loading")]
+        let mut conn = rsfbclient::builder_native()
+            .with_dyn_load("./fbclient.lib")
+            .with_remote()
+            .host("localhost")
+            .db_name("examples.fdb")
+            .user("SYSDBA")
+            .pass("masterkey")
+            .connect()?;
 
-    let wt = conn.listen_event("ping".to_string(), move |c| {
-        println!("Pong! Some rows here:");
+        let wt = conn.listen_event("ping".to_string(), move |c| {
+            println!("Pong! Some rows here:");
 
-        let rows: Vec<(String, String)> = c.query(
-            "select mon$attachment_name, mon$user from mon$attachments",
-            (),
-        )?;
+            let rows: Vec<(String, String)> = c.query(
+                "select mon$attachment_name, mon$user from mon$attachments",
+                (),
+            )?;
 
-        for row in rows {
-            println!("Attachment {}, user {}", row.0, row.1);
-        }
+            for row in rows {
+                println!("Attachment {}, user {}", row.0, row.1);
+            }
 
-        return Ok(true);
-    })?;
+            return Ok(true);
+        })?;
 
-    println!("Try ping here with \"POST_EVENT 'ping'\"");
+        println!("Try ping here with \"POST_EVENT 'ping'\"");
 
-    wt.join().unwrap()?;
+        wt.join().unwrap()?;
+    }
 
     Ok(())
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused_variables, unused_mut)]
 
-use rsfbclient::{FbError, RemoteEventsManager, Queryable};
+use rsfbclient::{FbError, Queryable, RemoteEventsManager};
 
 fn main() -> Result<(), FbError> {
     #[cfg(feature = "linking")]
@@ -30,7 +30,6 @@ fn main() -> Result<(), FbError> {
         .connect()?;
 
     let wt = conn.listen_event("ping".to_string(), move |c| {
-
         println!("Pong! Some rows here:");
 
         let rows: Vec<(String, String)> = c.query(

--- a/r2d2_firebird/src/lib.rs
+++ b/r2d2_firebird/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 
 use rsfbclient::{Connection, FbError, FirebirdClientFactory, Transaction};
-use rsfbclient_core::FirebirdClientDbOps;
+use rsfbclient_core::{FirebirdClientDbOps, TransactionConfiguration};
 
 /// A manager for connection pools. Requires the `pool` feature.
 pub struct FirebirdConnectionManager<F>
@@ -39,7 +39,7 @@ where
 
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         // If it can start a transaction, we are ok
-        Transaction::new(conn)?;
+        Transaction::new(conn, TransactionConfiguration::default())?;
         Ok(())
     }
 

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -134,11 +134,11 @@ pub trait FirebirdClientSqlOps {
         stmt_handle: &mut Self::StmtHandle,
     ) -> Result<Option<Vec<Column>>, FbError>;
 
-    /// Register a listner for some events
-    fn que_events(
+    /// Wait for an event to be posted on database
+    fn wait_for_event(
         &mut self,
         db_handle: &mut Self::DbHandle,
-        names: Vec<String>,
+        name: String,
     ) -> Result<(), FbError>;
 }
 

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -20,7 +20,7 @@ where
 {
 }
 
-///Responsible for database administration and attachment/detachment
+/// Responsible for database administration and attachment/detachment
 pub trait FirebirdClientDbOps: Send {
     /// A database handle
     type DbHandle: Send;
@@ -133,7 +133,10 @@ pub trait FirebirdClientSqlOps {
         tr_handle: &mut Self::TrHandle,
         stmt_handle: &mut Self::StmtHandle,
     ) -> Result<Option<Vec<Column>>, FbError>;
+}
 
+/// Firebird base event API
+pub trait FirebirdClientDbEvents: FirebirdClientDbOps {
     /// Wait for an event to be posted on database
     fn wait_for_event(
         &mut self,

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -133,6 +133,13 @@ pub trait FirebirdClientSqlOps {
         tr_handle: &mut Self::TrHandle,
         stmt_handle: &mut Self::StmtHandle,
     ) -> Result<Option<Vec<Column>>, FbError>;
+
+    /// Register a listner for some events
+    fn que_events(
+        &mut self,
+        db_handle: &mut Self::DbHandle,
+        names: Vec<String>
+    ) -> Result<(), FbError>;
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -138,7 +138,7 @@ pub trait FirebirdClientSqlOps {
     fn que_events(
         &mut self,
         db_handle: &mut Self::DbHandle,
-        names: Vec<String>
+        names: Vec<String>,
     ) -> Result<(), FbError>;
 }
 

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -624,6 +624,9 @@ impl<T: LinkageMarker> FirebirdClientDbEvents for NativeFbClient<T> {
                     result_buffer,
                 ) != 0
                 {
+                    self.ibase.isc_free()(event_buffer);
+                    self.ibase.isc_free()(result_buffer);
+
                     return Err(self.status.as_error(&self.ibase));
                 }
             }
@@ -647,8 +650,14 @@ impl<T: LinkageMarker> FirebirdClientDbEvents for NativeFbClient<T> {
                 result_buffer,
             ) != 0
             {
+                self.ibase.isc_free()(event_buffer);
+                self.ibase.isc_free()(result_buffer);
+
                 return Err(self.status.as_error(&self.ibase));
             }
+
+            self.ibase.isc_free()(event_buffer);
+            self.ibase.isc_free()(result_buffer);
         }
 
         Ok(())

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -589,17 +589,16 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
         Ok(rcol)
     }
 
-    /// Register a listner for some events
-    fn que_events(
+    /// Wait for an event to be posted on database
+    fn wait_for_event(
         &mut self,
         db_handle: &mut Self::DbHandle,
-        names: Vec<String>,
+        name: String,
     ) -> Result<(), FbError> {
         let mut event_buffer = ptr::null_mut();
         let mut result_buffer = ptr::null_mut();
 
-        // TODO: support multiple names
-        let name = CString::new(names[0].clone()).unwrap();
+        let name = CString::new(name.clone()).unwrap();
         let len = unsafe {
             self.ibase.isc_event_block()(
                 &mut event_buffer,

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -588,8 +588,9 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
 
         Ok(rcol)
     }
+}
 
-    /// Wait for an event to be posted on database
+impl<T: LinkageMarker> FirebirdClientDbEvents for NativeFbClient<T> {
     fn wait_for_event(
         &mut self,
         db_handle: &mut Self::DbHandle,

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -488,9 +488,9 @@ parse_functions! {
     //         arg5: ::std::os::raw::c_short,
     //     ) -> ::std::os::raw::c_int;
     // }
-    // extern "C" {
-    //     pub fn isc_free(arg1: *mut ISC_SCHAR) -> ISC_LONG;
-    // }
+    extern "C" {
+        pub fn isc_free(arg1: *mut ISC_UCHAR) -> ISC_LONG;
+    }
     extern "C" {
         pub fn isc_get_segment(
             arg1: *mut ISC_STATUS,

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -468,14 +468,14 @@ parse_functions! {
     //         arg5: *mut ISC_USHORT,
     //     );
     // }
-    // extern "C" {
-    //     pub fn isc_event_counts(
-    //         arg1: *mut ISC_ULONG,
-    //         arg2: ::std::os::raw::c_short,
-    //         arg3: *mut ISC_UCHAR,
-    //         arg4: *const ISC_UCHAR,
-    //     );
-    // }
+    extern "C" {
+        pub fn isc_event_counts(
+            arg1: *mut ISC_STATUS,
+            arg2: ::std::os::raw::c_short,
+            arg3: *mut ISC_UCHAR,
+            arg4: *const ISC_UCHAR,
+        ) -> ::std::os::raw::c_void;
+    }
     // extern "C" {
     //     pub fn isc_expand_dpb(arg1: *mut *mut ISC_SCHAR, arg2: *mut ::std::os::raw::c_short, ...);
     // }

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -443,14 +443,14 @@ parse_functions! {
     // extern "C" {
     //     pub fn isc_encode_timestamp(arg1: *const ::std::os::raw::c_void, arg2: *mut ISC_TIMESTAMP);
     // }
-    // extern "C" {
-    //     pub fn isc_event_block(
-    //         arg1: *mut *mut ISC_UCHAR,
-    //         arg2: *mut *mut ISC_UCHAR,
-    //         arg3: ISC_USHORT,
-    //         ...
-    //     ) -> ISC_LONG;
-    // }
+    extern "C" {
+        pub fn isc_event_block(
+            arg1: *mut *mut ISC_UCHAR,
+            arg2: *mut *mut ISC_UCHAR,
+            arg3: ISC_USHORT,
+            ...
+        ) -> ISC_LONG;
+    }
     // extern "C" {
     //     pub fn isc_event_block_a(
     //         arg1: *mut *mut ISC_SCHAR,
@@ -781,15 +781,15 @@ parse_functions! {
     //         arg3: ::std::os::raw::c_short,
     //     ) -> ISC_STATUS;
     // }
-    // extern "C" {
-    //     pub fn isc_wait_for_event(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: *mut isc_db_handle,
-    //         arg3: ::std::os::raw::c_short,
-    //         arg4: *const ISC_UCHAR,
-    //         arg5: *mut ISC_UCHAR,
-    //     ) -> ISC_STATUS;
-    // }
+    extern "C" {
+        pub fn isc_wait_for_event(
+            arg1: *mut ISC_STATUS,
+            arg2: *mut isc_db_handle,
+            arg3: ::std::os::raw::c_short,
+            arg4: *const ISC_UCHAR,
+            arg5: *mut ISC_UCHAR,
+        ) -> ISC_STATUS;
+    }
     // extern "C" {
     //     pub fn isc_close(arg1: *mut ISC_STATUS, arg2: *const ISC_SCHAR) -> ISC_STATUS;
     // }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -281,9 +281,9 @@ impl<C: FirebirdClient> Connection<C> {
         self.use_transaction(self.def_confs_tr, |tr| tr.rollback_retaining())
     }
 
-    /// Register a listner for some events
-    pub fn que_events(&mut self, names: Vec<String>) -> Result<(), FbError> {
-        self.cli.que_events(&mut self.handle, names)
+    /// Wait for an event to be posted on database
+    pub fn wait_for_event(&mut self, name: String) -> Result<(), FbError> {
+        self.cli.wait_for_event(&mut self.handle, name)
     }
 }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,8 +4,8 @@
 //! Connection functions
 //!
 use rsfbclient_core::{
-    Dialect, FbError, FirebirdClient, FirebirdClientDbOps, FromRow, IntoParams,
-    TransactionConfiguration,
+    Dialect, FbError, FirebirdClient, FirebirdClientDbEvents, FirebirdClientDbOps, FromRow,
+    IntoParams, TransactionConfiguration,
 };
 use std::{marker, mem};
 
@@ -280,10 +280,17 @@ impl<C: FirebirdClient> Connection<C> {
 
         self.use_transaction(self.def_confs_tr, |tr| tr.rollback_retaining())
     }
+}
 
+impl<C: FirebirdClient> Connection<C>
+where
+    C: FirebirdClientDbEvents,
+{
     /// Wait for an event to be posted on database
     pub fn wait_for_event(&mut self, name: String) -> Result<(), FbError> {
-        self.cli.wait_for_event(&mut self.handle, name)
+        self.cli.wait_for_event(&mut self.handle, name)?;
+
+        Ok(())
     }
 }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -280,6 +280,11 @@ impl<C: FirebirdClient> Connection<C> {
 
         self.use_transaction(self.def_confs_tr, |tr| tr.rollback_retaining())
     }
+
+    /// Register a listner for some events
+    pub fn que_events(&mut self, names: Vec<String>) -> Result<(), FbError> {
+        self.cli.que_events(&mut self.handle, names)
+    }
 }
 
 impl<C: FirebirdClient> Drop for Connection<C> {

--- a/src/connection/simple.rs
+++ b/src/connection/simple.rs
@@ -178,14 +178,16 @@ impl SimpleConnection {
     }
 
     /// Wait for an event to be posted on database
-    pub fn wait_for_event(&mut self, name: String) -> Result<(), FbError> {
+    pub(crate) fn wait_for_event(&mut self, name: String) -> Result<(), FbError> {
         match &mut self.inner {
             #[cfg(feature = "linking")]
             TypeConnectionContainer::NativeDynLink(c) => c.wait_for_event(name),
             #[cfg(feature = "dynamic_loading")]
             TypeConnectionContainer::NativeDynLoad(c) => c.wait_for_event(name),
             #[cfg(feature = "pure_rust")]
-            TypeConnectionContainer::PureRust(c) => c.wait_for_event(name),
+            TypeConnectionContainer::PureRust(c) => {
+                Err(FbError::from("Events only works with the native client"))
+            }
         }
     }
 }

--- a/src/connection/simple.rs
+++ b/src/connection/simple.rs
@@ -176,6 +176,18 @@ impl SimpleConnection {
             TypeConnectionContainer::PureRust(c) => c.rollback(),
         }
     }
+
+    /// Wait for an event to be posted on database
+    pub fn wait_for_event(&mut self, name: String) -> Result<(), FbError> {
+        match &mut self.inner {
+            #[cfg(feature = "linking")]
+            TypeConnectionContainer::NativeDynLink(c) => c.wait_for_event(name),
+            #[cfg(feature = "dynamic_loading")]
+            TypeConnectionContainer::NativeDynLoad(c) => c.wait_for_event(name),
+            #[cfg(feature = "pure_rust")]
+            TypeConnectionContainer::PureRust(c) => c.wait_for_event(name),
+        }
+    }
 }
 
 impl Execute for SimpleConnection {

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,96 @@
+//! Firebird remote events API
+
+use crate::Connection;
+use rsfbclient_core::{FbError, FirebirdClient};
+use std::ops::Fn;
+use std::marker::PhantomData;
+use std::thread::{self,JoinHandle};
+
+/// Firebird remote events manager
+pub struct RemoteEventsManager<'a, C, F>
+where
+    C: FirebirdClient,
+    F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
+{
+    conn: &'a mut Connection<C>,
+    events: Vec<RegisteredEvent<'a, F, C>>
+}
+
+impl<'a, C, F> RemoteEventsManager<'a, C, F>
+where
+    C: FirebirdClient,
+    F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
+{
+    pub fn init(conn: &'a mut Connection<C>) -> Result<Self, FbError> {
+        Ok(Self {
+            conn,
+            events: vec![]
+        })
+    }
+
+    /// Register a event with a callback
+    pub fn listen(&mut self, name: &'a str, closure: F) -> Result<(), FbError>
+    {
+        self.events.push(RegisteredEvent {
+            name,
+            phantom: PhantomData,
+            closure
+        });
+
+        Ok(())
+    }
+
+    /// Start the events listners
+    pub fn start(&mut self) -> Result<JoinHandle<()>, FbError> {
+        let th = thread::spawn(move || {
+            // some work here
+        });
+
+        Ok(th)
+    }
+}
+
+struct RegisteredEvent<'a, F, C>
+    where
+        F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
+{
+    name: &'a str,
+    phantom: PhantomData<&'a C>,
+    closure: F
+}
+
+#[cfg(test)]
+mk_tests_default! {
+    use crate::*;
+
+    #[test]
+    fn remote_events() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        let mut mn = RemoteEventsManager::init(&mut conn)?;
+
+        let mut counter = 0;
+
+        mn.listen("evento", |c| {
+
+            let (_,): (i32,) = c.query_first(
+                "select 1 from rdb$database",
+                (),
+            )?.unwrap();
+
+            counter = 1;
+
+            Ok(())
+        })?;
+
+        let th = mn.start()?;
+
+        conn.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
+
+        th.join().expect("Join thread fail");
+
+        assert_eq!(1, counter);
+
+        Ok(())
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -59,7 +59,8 @@ mk_tests_default! {
     use std::thread;
 
     #[test]
-    #[cfg(all(feature = "linking", not(feature = "embedded_tests")))]
+    #[ignore]
+    #[cfg(all(not(feature = "pure_rust"), not(feature = "embedded_tests")))]
     fn remote_events_native() -> Result<(), FbError> {
         let conn1 = cbuilder().connect()?;
         let mut conn2 = cbuilder().connect()?;
@@ -98,7 +99,8 @@ mk_tests_default! {
     }
 
     #[test]
-    #[cfg(all(feature = "linking", not(feature = "embedded_tests")))]
+    #[ignore]
+    #[cfg(all(not(feature = "pure_rust"), not(feature = "embedded_tests")))]
     fn wait_for_event() -> Result<(), FbError> {
 
         let mut conn1 = cbuilder().connect()?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -42,8 +42,15 @@ where
 
     /// Start the events listners
     pub fn start(&mut self) -> Result<JoinHandle<()>, FbError> {
-        let th = thread::spawn(move || {
-            // some work here
+
+        let names = self.events.iter()
+            .map(|e| e.name.to_string())
+            .collect();
+
+        self.conn.que_events(names)?;
+
+        let th = thread::spawn(|| {
+            //loop {}
         });
 
         Ok(th)

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,14 +1,14 @@
 //! Firebird remote events API
 
 use crate::{Connection, SimpleConnection};
-use rsfbclient_core::{FbError, FirebirdClient};
+use rsfbclient_core::{FbError, FirebirdClient, FirebirdClientDbEvents};
 use std::thread::{self, JoinHandle};
 
 /// Firebird remote events manager
 pub trait RemoteEventsManager<F, C>
 where
     F: FnMut(&mut SimpleConnection) -> Result<bool, FbError> + Send + Sync + 'static,
-    C: FirebirdClient + 'static,
+    C: FirebirdClient + FirebirdClientDbEvents + 'static,
     SimpleConnection: From<Connection<C>>,
 {
     /// Start the event listener on a thread
@@ -26,7 +26,7 @@ where
 
 impl<F, C> RemoteEventsManager<F, C> for Connection<C>
 where
-    C: FirebirdClient + 'static,
+    C: FirebirdClient + FirebirdClientDbEvents + 'static,
     F: FnMut(&mut SimpleConnection) -> Result<bool, FbError> + Send + Sync + 'static,
     SimpleConnection: From<Connection<C>>,
 {
@@ -98,7 +98,7 @@ mk_tests_default! {
     }
 
     #[test]
-    #[cfg(not(feature = "embedded_tests"))]
+    #[cfg(all(feature = "linking", not(feature = "embedded_tests")))]
     fn wait_for_event() -> Result<(), FbError> {
 
         let mut conn1 = cbuilder().connect()?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,87 +1,54 @@
 //! Firebird remote events API
 
-use crate::{Connection, FirebirdClientFactory};
+use crate::{Connection, SimpleConnection};
 use rsfbclient_core::{FbError, FirebirdClient};
-use std::marker::PhantomData;
 use std::thread::{self, JoinHandle};
 
 /// Firebird remote events manager
-pub struct RemoteEventsManager<C, F, FA>
+pub trait RemoteEventsManager<F, C>
 where
-    C: FirebirdClient + Send + Sync,
-    F: FnMut(&mut Connection<C>) -> Result<(), FbError> + Send + Sync + 'static,
-    FA: FirebirdClientFactory<C = C> + Send + Sync + Clone + 'static,
+    F: FnMut(&mut SimpleConnection) -> Result<bool, FbError> + Send + Sync + 'static,
+    C: FirebirdClient + 'static,
+    SimpleConnection: From<Connection<C>>,
 {
-    events: Vec<RegisteredEvent<F, C>>,
-    conn_builder: FA,
+    /// Start the event listener on a thread
+    ///
+    /// The event can be called many times.
+    ///
+    /// Stop when the handler return a error. Return a false
+    /// value if you want stop the listner,
+    fn listen_event(
+        self,
+        name: String,
+        handler: F,
+    ) -> Result<JoinHandle<Result<(), FbError>>, FbError>;
 }
 
-impl<C, F, FA> RemoteEventsManager<C, F, FA>
+impl<F, C> RemoteEventsManager<F, C> for Connection<C>
 where
-    C: FirebirdClient + Send + Sync,
-    F: FnMut(&mut Connection<C>) -> Result<(), FbError> + Send + Sync + 'static,
-    FA: FirebirdClientFactory<C = C> + Send + Sync + Clone + 'static,
+    C: FirebirdClient + 'static,
+    F: FnMut(&mut SimpleConnection) -> Result<bool, FbError> + Send + Sync + 'static,
+    SimpleConnection: From<Connection<C>>,
 {
-    pub fn init(fac: FA) -> Result<Self, FbError> {
-        Ok(Self {
-            events: vec![],
-            conn_builder: fac,
-        })
-    }
+    fn listen_event(
+        self,
+        name: String,
+        mut handler: F,
+    ) -> Result<JoinHandle<Result<(), FbError>>, FbError> {
+        let mut conn: SimpleConnection = self.into();
 
-    /// Register a event with a callback
-    pub fn listen(&mut self, name: String, closure: F) -> Result<(), FbError> {
-        self.events.push(RegisteredEvent {
-            name,
-            phantom: PhantomData,
-            closure,
-        });
+        return Ok(thread::spawn(move || {
+            let mut hold = true;
 
-        Ok(())
-    }
+            while hold {
+                conn.wait_for_event(name.clone())?;
 
-    /// Start the events listners
-    pub fn start(self) -> Result<JoinHandle<Result<(), FbError>>, FbError> {
-        let mut threads: Vec<JoinHandle<Result<(), FbError>>> = vec![];
-
-        for event in self.events {
-            let cb = self.conn_builder.clone();
-
-            let th = thread::spawn(move || {
-                let cli = cb.new_instance()?;
-                let mut conn = Connection::open(cli, cb.get_conn_conf())?;
-
-                let mut call = event.closure;
-                loop {
-                    conn.wait_for_event(event.name.clone())?;
-
-                    call(&mut conn)?;
-                }
-            });
-            threads.push(th);
-        }
-
-        let ctl = thread::spawn(|| {
-            for th in threads {
-                let _ = th
-                    .join()
-                    .map_err(|_| FbError::from("Join internal thread"))?;
+                hold = handler(&mut conn)?;
             }
 
             Ok(())
-        });
-
-        Ok(ctl)
+        }));
     }
-}
-
-struct RegisteredEvent<F, C>
-where
-    F: FnMut(&mut Connection<C>) -> Result<(), FbError> + Send + 'static,
-{
-    name: String,
-    phantom: PhantomData<C>,
-    closure: F,
 }
 
 #[cfg(test)]
@@ -94,16 +61,13 @@ mk_tests_default! {
     #[test]
     #[cfg(all(feature = "linking", not(feature = "embedded_tests")))]
     fn remote_events_native() -> Result<(), FbError> {
-        let cb = builder_native()
-            .with_dyn_link()
-            .with_remote();
-
-        let mut mn = RemoteEventsManager::init(cb)?;
+        let conn1 = cbuilder().connect()?;
+        let mut conn2 = cbuilder().connect()?;
 
         let counter = Arc::new(Mutex::new(0)).clone();
 
         let acounter = Arc::clone(&counter);
-        mn.listen("evento".to_string(), move |c| {
+        let _ = conn1.listen_event("evento".to_string(), move |c| {
 
             let (_,): (i32,) = c.query_first(
                 "select 1 from rdb$database",
@@ -113,22 +77,45 @@ mk_tests_default! {
             let mut num = acounter.lock().unwrap();
             *num += 1;
 
-            Ok(())
+            Ok(*num < 2)
         })?;
 
-        let _ = mn.start()?;
+        thread::sleep(Duration::from_secs(2));
 
-        thread::sleep(Duration::from_secs(5));
-
-        let mut conn = cbuilder().connect()?;
-
-        conn.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
+        conn2.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
         thread::sleep(Duration::from_secs(2));
         assert_eq!(1, *counter.lock().unwrap());
 
-        conn.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
+        conn2.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
         thread::sleep(Duration::from_secs(2));
         assert_eq!(2, *counter.lock().unwrap());
+
+        conn2.execute("execute block as begin POST_EVENT 'evento'; end", ())?;
+        thread::sleep(Duration::from_secs(2));
+        assert_eq!(2, *counter.lock().unwrap());
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(not(feature = "embedded_tests"))]
+    fn wait_for_event() -> Result<(), FbError> {
+
+        let mut conn1 = cbuilder().connect()?;
+        let mut conn2 = cbuilder().connect()?;
+
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(2));
+
+            conn1.execute("execute block as begin POST_EVENT 'evento'; end", ())
+        });
+
+        let wait = thread::spawn(move || {
+            conn2.wait_for_event("evento".to_string())
+        });
+
+        thread::sleep(Duration::from_secs(10));
+        assert!(wait.is_finished());
 
         Ok(())
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,9 +2,9 @@
 
 use crate::Connection;
 use rsfbclient_core::{FbError, FirebirdClient};
-use std::ops::Fn;
 use std::marker::PhantomData;
-use std::thread::{self,JoinHandle};
+use std::ops::Fn;
+use std::thread::{self, JoinHandle};
 
 /// Firebird remote events manager
 pub struct RemoteEventsManager<'a, C, F>
@@ -13,7 +13,7 @@ where
     F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
 {
     conn: &'a mut Connection<C>,
-    events: Vec<RegisteredEvent<'a, F, C>>
+    events: Vec<RegisteredEvent<'a, F, C>>,
 }
 
 impl<'a, C, F> RemoteEventsManager<'a, C, F>
@@ -24,17 +24,16 @@ where
     pub fn init(conn: &'a mut Connection<C>) -> Result<Self, FbError> {
         Ok(Self {
             conn,
-            events: vec![]
+            events: vec![],
         })
     }
 
     /// Register a event with a callback
-    pub fn listen(&mut self, name: &'a str, closure: F) -> Result<(), FbError>
-    {
+    pub fn listen(&mut self, name: &'a str, closure: F) -> Result<(), FbError> {
         self.events.push(RegisteredEvent {
             name,
             phantom: PhantomData,
-            closure
+            closure,
         });
 
         Ok(())
@@ -42,10 +41,7 @@ where
 
     /// Start the events listners
     pub fn start(&mut self) -> Result<JoinHandle<()>, FbError> {
-
-        let names = self.events.iter()
-            .map(|e| e.name.to_string())
-            .collect();
+        let names = self.events.iter().map(|e| e.name.to_string()).collect();
 
         self.conn.que_events(names)?;
 
@@ -58,12 +54,12 @@ where
 }
 
 struct RegisteredEvent<'a, F, C>
-    where
-        F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
+where
+    F: FnMut(&mut Connection<C>) -> Result<(), FbError>,
 {
     name: &'a str,
     phantom: PhantomData<&'a C>,
-    closure: F
+    closure: F,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod prelude {
 }
 
 mod connection;
+mod events;
 mod query;
 mod statement;
 mod transaction;
@@ -94,6 +95,7 @@ mod utils;
 
 pub use crate::{
     connection::{Connection, ConnectionConfiguration, FirebirdClientFactory, SimpleConnection},
+    events::RemoteEventsManager,
     query::{Execute, Queryable},
     statement::Statement,
     transaction::{SimpleTransaction, Transaction},


### PR DESCRIPTION
Firebird events support added. Now the users can listen for posted events by triggers and others.

Only for native client. The wire protocol is too complex to implement now.

Basically now we have `wait_for_event` method directly on the connection struct and a more complex solution with `listen_event` method from `RemoteEventManager`.