### PR TITLE
Custom blob subtypes

### DIFF
--- a/rsfbclient-diesel/Cargo.toml
+++ b/rsfbclient-diesel/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.0.0", default-features = false, features = ["chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"]}
+diesel = { version = "=2.0.0", default-features = false, features = ["chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"]}
 rsfbclient = { version = "0.23.0", path = "../", default-features = false }
 byteorder = "1.4.3"
 bytes = "1.0.1"

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -76,8 +76,7 @@ impl ColumnBuffer {
                 Boolean(Box::new(0))
             }
 
-            // BLOB sql_type text are considered a normal text on read
-            ibase::SQL_BLOB if (sqlsubtype == 0 || sqlsubtype == 1) => {
+            ibase::SQL_BLOB if (sqlsubtype <= 1) => {
                 let blob_id = Box::new(ibase::GDS_QUAD_t {
                     gds_quad_high: 0,
                     gds_quad_low: 0,
@@ -85,7 +84,9 @@ impl ColumnBuffer {
 
                 var.sqltype = ibase::SQL_BLOB as i16 + 1;
 
-                if sqlsubtype == 0 {
+                // subtype 0: binary
+                // subtype <= -1: custom
+                if sqlsubtype <= 0 {
                     BlobBinary(blob_id)
                 } else {
                     BlobText(blob_id)

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -646,7 +646,7 @@ pub fn parse_sql_response(
                 }
             }
 
-            ibase::SQL_BLOB if var.sqlsubtype == 0 || var.sqlsubtype == 1 => {
+            ibase::SQL_BLOB if var.sqlsubtype <= 1 => {
                 let id = resp.get_u64()?;
 
                 let null = read_null(resp, col_index)?;

--- a/rsfbclient-rust/src/xsqlda.rs
+++ b/rsfbclient-rust/src/xsqlda.rs
@@ -96,7 +96,7 @@ impl XSqlVar {
                 self.sqltype = ibase::SQL_TIMESTAMP as i16 + 1;
             }
 
-            ibase::SQL_BLOB if (sqlsubtype == 0 || sqlsubtype == 1) => {
+            ibase::SQL_BLOB if (sqlsubtype <= 1) => {
                 self.sqltype = ibase::SQL_BLOB as i16 + 1;
             }
 

--- a/rsfbclient-rust/src/xsqlda.rs
+++ b/rsfbclient-rust/src/xsqlda.rs
@@ -96,7 +96,7 @@ impl XSqlVar {
                 self.sqltype = ibase::SQL_TIMESTAMP as i16 + 1;
             }
 
-            ibase::SQL_BLOB if (sqlsubtype <= 1) => {
+            ibase::SQL_BLOB if sqlsubtype <= 1 => {
                 self.sqltype = ibase::SQL_BLOB as i16 + 1;
             }
 

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -203,6 +203,18 @@ mk_tests_default! {
     }
 
     #[test]
+    fn blob_custom_subtype() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        let (a,): (Option<Vec<u8>>,) = conn.query_first("select cast(null as blob SUB_TYPE -1) from rdb$database;", ())?
+            .unwrap();
+
+        assert_eq!(None, a);
+
+        Ok(())
+    }
+
+    #[test]
     fn dates() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 


### PR DESCRIPTION
Support for custom blob subtypes added.

Blob subtypes supported now:
- 1: TEXT
- 0: binary
- <= -1: custom

Issue #146