### PR TITLE
Dialect on create_database and no_db_trigger support

### DIFF
--- a/examples/createdb.rs
+++ b/examples/createdb.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), FbError> {
         .user("SYSDBA")
         .pass("masterkey")
         .page_size(8 * 1024) // Optional
+        .dialect(rsfbclient::Dialect::D1)
         .create_database()?;
 
     #[cfg(feature = "dynamic_loading")]
@@ -38,6 +39,7 @@ fn main() -> Result<(), FbError> {
         .user("SYSDBA")
         .pass("masterkey")
         .page_size(16 * 1024) // Optional
+        .dialect(rsfbclient::Dialect::D3)
         .create_database()?;
 
     conn.close()?;

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -37,6 +37,7 @@ pub trait FirebirdClientDbOps: Send {
         &mut self,
         config: &Self::AttachmentConfig,
         dialect: Dialect,
+        no_db_triggers: bool,
     ) -> Result<Self::DbHandle, FbError>;
 
     /// Disconnect from the database

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -152,9 +152,9 @@ pub trait FirebirdClientDbEvents: FirebirdClientDbOps {
 #[repr(u8)]
 /// Firebird sql dialect
 pub enum Dialect {
-    #[default]
     D1 = 1,
     D2 = 2,
+    #[default]
     D3 = 3,
 }
 

--- a/rsfbclient-core/src/connection.rs
+++ b/rsfbclient-core/src/connection.rs
@@ -36,6 +36,7 @@ pub trait FirebirdClientDbOps: Send {
     fn attach_database(
         &mut self,
         config: &Self::AttachmentConfig,
+        dialect: Dialect,
     ) -> Result<Self::DbHandle, FbError>;
 
     /// Disconnect from the database
@@ -50,6 +51,7 @@ pub trait FirebirdClientDbOps: Send {
         &mut self,
         config: &Self::AttachmentConfig,
         page_size: Option<u32>,
+        dialect: Dialect,
     ) -> Result<Self::DbHandle, FbError>;
 }
 
@@ -145,10 +147,11 @@ pub trait FirebirdClientDbEvents: FirebirdClientDbOps {
     ) -> Result<(), FbError>;
 }
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
 #[repr(u8)]
 /// Firebird sql dialect
 pub enum Dialect {
+    #[default]
     D1 = 1,
     D2 = 2,
     D3 = 3,

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -114,9 +114,15 @@ impl<T: LinkageMarker> FirebirdClientDbOps for NativeFbClient<T> {
         &mut self,
         config: &Self::AttachmentConfig,
         dialect: Dialect,
+        no_db_triggers: bool,
     ) -> Result<NativeDbHandle, FbError> {
-        let (dpb, conn_string) = self.build_dpb(config, dialect);
+        let (mut dpb, conn_string) = self.build_dpb(config, dialect);
         let mut handle = 0;
+
+        if no_db_triggers {
+            dpb.extend(&[ibase::isc_dpb_no_db_triggers as u8, 1 as u8]);
+            dpb.extend(&[1 as u8]);
+        }
 
         unsafe {
             if self.ibase.isc_attach_database()(

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -85,6 +85,7 @@ impl FirebirdClientDbOps for RustFbClient {
     fn attach_database(
         &mut self,
         config: &Self::AttachmentConfig,
+        dialect: Dialect,
     ) -> Result<RustDbHandle, FbError> {
         let host = config.host.as_str();
         let port = config.port;
@@ -109,7 +110,7 @@ impl FirebirdClientDbOps for RustFbClient {
             )?,
         };
 
-        let attach_result = conn.attach_database(db_name, user, pass, role);
+        let attach_result = conn.attach_database(db_name, user, pass, role, dialect);
 
         // Put the connection back
         self.conn.replace(conn);
@@ -135,6 +136,7 @@ impl FirebirdClientDbOps for RustFbClient {
         &mut self,
         config: &Self::AttachmentConfig,
         page_size: Option<u32>,
+        dialect: Dialect,
     ) -> Result<RustDbHandle, FbError> {
         let host = config.host.as_str();
         let port = config.port;
@@ -159,7 +161,7 @@ impl FirebirdClientDbOps for RustFbClient {
             )?,
         };
 
-        let attach_result = conn.create_database(db_name, user, pass, page_size, role);
+        let attach_result = conn.create_database(db_name, user, pass, page_size, role, dialect);
 
         // Put the connection back
         self.conn.replace(conn);
@@ -391,6 +393,7 @@ impl FirebirdWireConnection {
         pass: &str,
         page_size: Option<u32>,
         role_name: Option<&str>,
+        dialect: Dialect,
     ) -> Result<DbHandle, FbError> {
         self.socket.write_all(&create(
             db_name,
@@ -400,6 +403,7 @@ impl FirebirdWireConnection {
             self.charset.clone(),
             page_size,
             role_name.clone(),
+            dialect,
         ))?;
         self.socket.flush()?;
 
@@ -415,6 +419,7 @@ impl FirebirdWireConnection {
         user: &str,
         pass: &str,
         role_name: Option<&str>,
+        dialect: Dialect,
     ) -> Result<DbHandle, FbError> {
         self.socket.write_all(&attach(
             db_name,
@@ -423,6 +428,7 @@ impl FirebirdWireConnection {
             self.version,
             self.charset.clone(),
             role_name.clone(),
+            dialect,
         ))?;
         self.socket.flush()?;
 
@@ -1042,7 +1048,9 @@ fn connection_test() {
     let mut conn =
         FirebirdWireConnection::connect("127.0.0.1", 3050, db_name, user, pass, UTF_8).unwrap();
 
-    let mut db_handle = conn.attach_database(db_name, user, pass, None).unwrap();
+    let mut db_handle = conn
+        .attach_database(db_name, user, pass, None, Dialect::D3)
+        .unwrap();
 
     let mut tr_handle = conn
         .begin_transaction(&mut db_handle, TransactionConfiguration::default())

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -140,8 +140,18 @@ pub fn attach(
     charset: Charset,
     role_name: Option<&str>,
     dialect: Dialect,
+    no_db_triggers: bool,
 ) -> Bytes {
-    let dpb = build_dpb(user, pass, protocol, charset, None, role_name, dialect);
+    let dpb = build_dpb(
+        user,
+        pass,
+        protocol,
+        charset,
+        None,
+        role_name,
+        dialect,
+        no_db_triggers,
+    );
 
     let mut attach = BytesMut::with_capacity(16 + db_name.len() + dpb.len());
 
@@ -166,7 +176,9 @@ pub fn create(
     role_name: Option<&str>,
     dialect: Dialect,
 ) -> Bytes {
-    let dpb = build_dpb(user, pass, protocol, charset, page_size, role_name, dialect);
+    let dpb = build_dpb(
+        user, pass, protocol, charset, page_size, role_name, dialect, false,
+    );
 
     let mut create = BytesMut::with_capacity(16 + db_name.len() + dpb.len());
 
@@ -189,6 +201,7 @@ fn build_dpb(
     page_size: Option<u32>,
     role_name: Option<&str>,
     dialect: Dialect,
+    no_db_triggers: bool,
 ) -> Bytes {
     let mut dpb = BytesMut::with_capacity(64);
 
@@ -214,6 +227,11 @@ fn build_dpb(
 
     dpb.extend(&[ibase::isc_dpb_sql_dialect as u8, 1 as u8]);
     dpb.extend(&[dialect as u8]);
+
+    if no_db_triggers {
+        dpb.extend(&[ibase::isc_dpb_no_db_triggers as u8, 1 as u8]);
+        dpb.extend(&[1 as u8]);
+    }
 
     match protocol {
         // Plaintext password

--- a/src/connection/builders/builder_native.rs
+++ b/src/connection/builders/builder_native.rs
@@ -214,6 +214,12 @@ where
         self.conn_conf.transaction_conf = builder(&mut transaction_builder()).build();
         self
     }
+
+    /// Disabled the database triggers
+    pub fn no_db_triggers(&mut self) -> &mut Self {
+        self.conn_conf.no_db_triggers = true;
+        self
+    }
 }
 
 impl<A, B> NativeConnectionBuilder<A, B> {

--- a/src/connection/builders/builder_pure_rust.rs
+++ b/src/connection/builders/builder_pure_rust.rs
@@ -106,6 +106,12 @@ impl PureRustConnectionBuilder {
         self
     }
 
+    /// Disabled the database triggers
+    pub fn no_db_triggers(&mut self) -> &mut Self {
+        self.0.no_db_triggers = true;
+        self
+    }
+
     /// Default transaction configuration
     pub fn transaction(&mut self, conf: TransactionConfiguration) -> &mut Self {
         self.0.transaction_conf = conf;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -60,6 +60,7 @@ pub trait FirebirdClientFactory {
 pub struct ConnectionConfiguration<A> {
     attachment_conf: A,
     dialect: Dialect,
+    no_db_triggers: bool,
     stmt_cache_size: usize,
     transaction_conf: TransactionConfiguration,
 }
@@ -71,6 +72,7 @@ impl<A: Default> Default for ConnectionConfiguration<A> {
             dialect: Dialect::D3,
             stmt_cache_size: 20,
             transaction_conf: TransactionConfiguration::default(),
+            no_db_triggers: false,
         }
     }
 }
@@ -107,7 +109,8 @@ impl<C: FirebirdClient> Connection<C> {
         mut cli: C,
         conf: &ConnectionConfiguration<C::AttachmentConfig>,
     ) -> Result<Connection<C>, FbError> {
-        let handle = cli.attach_database(&conf.attachment_conf, conf.dialect)?;
+        let handle =
+            cli.attach_database(&conf.attachment_conf, conf.dialect, conf.no_db_triggers)?;
         let stmt_cache = StmtCache::new(conf.stmt_cache_size);
 
         Ok(Connection {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -107,7 +107,7 @@ impl<C: FirebirdClient> Connection<C> {
         mut cli: C,
         conf: &ConnectionConfiguration<C::AttachmentConfig>,
     ) -> Result<Connection<C>, FbError> {
-        let handle = cli.attach_database(&conf.attachment_conf)?;
+        let handle = cli.attach_database(&conf.attachment_conf, conf.dialect)?;
         let stmt_cache = StmtCache::new(conf.stmt_cache_size);
 
         Ok(Connection {
@@ -127,7 +127,7 @@ impl<C: FirebirdClient> Connection<C> {
         conf: &ConnectionConfiguration<C::AttachmentConfig>,
         page_size: Option<u32>,
     ) -> Result<Connection<C>, FbError> {
-        let handle = cli.create_database(&conf.attachment_conf, page_size)?;
+        let handle = cli.create_database(&conf.attachment_conf, page_size, conf.dialect)?;
         let stmt_cache = StmtCache::new(conf.stmt_cache_size);
 
         Ok(Connection {

--- a/src/tests/database.rs
+++ b/src/tests/database.rs
@@ -139,4 +139,38 @@ mk_tests_default! {
 
         Ok(())
     }
+
+    #[test]
+    #[cfg(all(feature = "linking", not(feature = "embedded_tests"), not(feature = "pure_rust")))]
+    fn dyn_linking_create_with_invalid_dialect() -> Result<(), FbError> {
+
+        let rs = builder_native()
+            .with_dyn_link()
+            .with_remote()
+            .db_name("test_create_db5.fdb")
+            .user("SYSDBA")
+            .host("localhost")
+            .dialect(rsfbclient::Dialect::D2)
+            .create_database();
+
+        assert!(rs.is_err());
+        assert!(rs.err().unwrap().to_string().contains("Database dialect 2 is not a valid dialec"));
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "pure_rust", not(feature = "native_client")))]
+    fn pure_rust_create_with_invalid_dialect() -> Result<(), FbError> {
+        let rs = builder_pure_rust()
+            .db_name("test_create_db55.fdb")
+            .user("SYSDBA")
+            .dialect(rsfbclient::Dialect::D2)
+            .create_database();
+
+        assert!(rs.is_err());
+        assert!(rs.err().unwrap().to_string().contains("Database dialect 2 is not a valid dialec"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
The `dialect` connection builder options now are also applied on database creation, provided by `create_database` method. 

`no_db_trigger` option added on connection builder, applied on database connection, disabling the database triggers. Table triggers are no affected.
