### PR TITLE
fix compatibility issues 

### DIFF
--- a/rsfbclient-native/src/varchar.rs
+++ b/rsfbclient-native/src/varchar.rs
@@ -35,7 +35,10 @@ impl Varchar {
     pub fn as_bytes(&self) -> &[u8] {
         let len = u16::min(self.capacity, unsafe { self.ptr.as_ref().len }) as usize;
 
-        unsafe { self.ptr.as_ref().data.get_unchecked(..len) }
+        unsafe {
+            let ptr = self.ptr.as_ref().data.as_ptr();
+            std::slice::from_raw_parts(ptr, len).get_unchecked(..len)
+        }
     }
 
     /// Get the pointer to the inner type

--- a/rsfbclient-native/src/xsqlda.rs
+++ b/rsfbclient-native/src/xsqlda.rs
@@ -36,7 +36,9 @@ impl XSqlDa {
     /// Returns a mutable reference to a XSQLVAR
     pub fn get_xsqlvar_mut(&mut self, col: usize) -> Option<&mut ibase::XSQLVAR> {
         if col < self.len as usize {
-            let xsqlvar = unsafe { self.ptr.as_mut().sqlvar.get_unchecked_mut(col as usize) };
+            let xsqlvar = unsafe { 
+                let ptr = self.ptr.as_mut().sqlvar.as_mut_ptr();
+                std::slice::from_raw_parts_mut(ptr,self.len as usize).get_unchecked_mut(col as usize) };
 
             Some(xsqlvar)
         } else {

--- a/rsfbclient-native/src/xsqlda.rs
+++ b/rsfbclient-native/src/xsqlda.rs
@@ -36,9 +36,11 @@ impl XSqlDa {
     /// Returns a mutable reference to a XSQLVAR
     pub fn get_xsqlvar_mut(&mut self, col: usize) -> Option<&mut ibase::XSQLVAR> {
         if col < self.len as usize {
-            let xsqlvar = unsafe { 
+            let xsqlvar = unsafe {
                 let ptr = self.ptr.as_mut().sqlvar.as_mut_ptr();
-                std::slice::from_raw_parts_mut(ptr,self.len as usize).get_unchecked_mut(col as usize) };
+                std::slice::from_raw_parts_mut(ptr, self.len as usize)
+                    .get_unchecked_mut(col as usize)
+            };
 
             Some(xsqlvar)
         } else {


### PR DESCRIPTION
using slice::from_raw_parts to genereta a new slice with a mutable size. to avoid the new bound checking on get_unchecked and get_unchecked_mut