### PR TITLE
Add isolation/type-mapping examples and document transaction and type semantics

### DIFF
--- a/examples/isolation_levels.rs
+++ b/examples/isolation_levels.rs
@@ -1,0 +1,137 @@
+//!
+//! Rust Firebird Client
+//!
+//! Example of explicit transactions and isolation levels
+//!
+//! Two connections to the same database demonstrate what the
+//! TransactionConfiguration options actually change inside Firebird:
+//!
+//!  1. Visibility: a Concurrency (SNAPSHOT) transaction does not see a
+//!     commit that happens after it starts; a ReadCommited one does.
+//!  2. Conflict policy: with TrLockResolution::NoWait, updating a row
+//!     that another transaction updated first fails immediately with
+//!     "update conflicts with concurrent update" instead of blocking.
+//!
+//! The example uses explicit `SimpleTransaction` objects instead of the
+//! connection's default transaction on purpose: the default transaction
+//! is started once with the configuration given at connect time, and
+//! `Connection::commit`/`rollback` are RETAINING operations — the same
+//! physical transaction (with its configuration and, under SNAPSHOT,
+//! its snapshot) lives for the whole life of the connection. Explicit
+//! transaction objects give each demonstration its own configuration
+//! and a real, consuming commit.
+//!
+//! The table is created by the example itself (idempotent); you only
+//! need an `examples.fdb` database.
+//!
+
+#![allow(unused_variables, unused_mut)]
+
+use rsfbclient::{prelude::*, FbError, SimpleConnection, SimpleTransaction};
+
+fn connect() -> Result<SimpleConnection, FbError> {
+    #[cfg(feature = "linking")]
+    let conn = rsfbclient::builder_native()
+        .with_dyn_link()
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    #[cfg(feature = "dynamic_loading")]
+    let conn = rsfbclient::builder_native()
+        .with_dyn_load("./fbclient.lib")
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    #[cfg(feature = "pure_rust")]
+    let conn = rsfbclient::builder_pure_rust()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    Ok(conn)
+}
+
+fn main() -> Result<(), FbError> {
+    let mut conn_a = connect()?;
+    let mut conn_b = connect()?;
+
+    let snapshot = TransactionConfiguration {
+        isolation: TrIsolationLevel::Concurrency,
+        lock_resolution: TrLockResolution::NoWait,
+        ..TransactionConfiguration::default()
+    };
+    let read_committed = TransactionConfiguration {
+        isolation: TrIsolationLevel::ReadCommited(TrRecordVersion::RecordVersion),
+        lock_resolution: TrLockResolution::NoWait,
+        ..TransactionConfiguration::default()
+    };
+
+    // Scratch table (idempotent)
+    {
+        let mut setup = SimpleTransaction::new(&mut conn_a, read_committed)?;
+        let _ = setup.execute("drop table accounts", ());
+        setup.execute(
+            "create table accounts (id int not null primary key, balance int)",
+            (),
+        )?;
+        setup.commit()?;
+
+        let mut setup = SimpleTransaction::new(&mut conn_a, read_committed)?;
+        setup.execute("insert into accounts values (1, 100)", ())?;
+        setup.commit()?;
+    }
+
+    // 1. Visibility
+    let mut tr_a = SimpleTransaction::new(&mut conn_a, snapshot)?;
+    let (balance,): (i64,) = tr_a
+        .query_first("select balance from accounts where id = 1", ())?
+        .unwrap();
+    println!("snapshot transaction sees balance {} at start", balance);
+
+    {
+        let mut tr_b = SimpleTransaction::new(&mut conn_b, read_committed)?;
+        tr_b.execute("update accounts set balance = 150 where id = 1", ())?;
+        tr_b.commit()?;
+        println!("another connection committed balance = 150");
+    }
+
+    let (still,): (i64,) = tr_a
+        .query_first("select balance from accounts where id = 1", ())?
+        .unwrap();
+    println!("snapshot transaction still sees {} (stable view)", still);
+    tr_a.commit()?;
+
+    let mut tr_rc = SimpleTransaction::new(&mut conn_a, read_committed)?;
+    let (now,): (i64,) = tr_rc
+        .query_first("select balance from accounts where id = 1", ())?
+        .unwrap();
+    println!("read committed transaction sees {} (follows commits)", now);
+    tr_rc.commit()?;
+
+    // 2. NoWait conflict
+    let mut tr_a = SimpleTransaction::new(&mut conn_a, snapshot)?;
+    let mut tr_b = SimpleTransaction::new(&mut conn_b, snapshot)?;
+    tr_a.execute("update accounts set balance = balance + 1 where id = 1", ())?;
+    println!("transaction A updated the row (uncommitted)");
+    match tr_b.execute("update accounts set balance = balance + 2 where id = 1", ()) {
+        Ok(_) => println!("unexpected: conflicting update succeeded"),
+        Err(e) => println!("conflicting update failed as designed:\n    {}", e),
+    }
+    tr_b.rollback()?;
+    tr_a.commit()?;
+
+    Ok(())
+}

--- a/examples/type_mapping.rs
+++ b/examples/type_mapping.rs
@@ -1,0 +1,152 @@
+//!
+//! Rust Firebird Client
+//!
+//! Example of how Firebird data types map to Rust types
+//!
+//! The driver's `SqlType` is deliberately coarse: every integer arrives
+//! as i64, every float / NUMERIC / DECIMAL as f64, CHAR/VARCHAR as
+//! String, BLOB as Vec<u8> or String, TIMESTAMP as chrono types and
+//! BOOLEAN as bool. This example shows each mapping live, plus the two
+//! sharp edges worth knowing:
+//!
+//!  - NUMERIC/DECIMAL are converted through f64, so scaled values whose
+//!    integer form exceeds 2^53 silently lose precision (shown below
+//!    with a value that comes back one cent off).
+//!  - Firebird 4+ types (INT128, DECFLOAT, TIMESTAMP/TIME WITH TIME
+//!    ZONE) and blobs with sub_type > 1 are not supported by the row
+//!    reader: selecting such a column fails at describe time with
+//!    "Unsupported column type". CAST them to VARCHAR (or BIGINT etc.)
+//!    in SQL to move the conversion server-side.
+//!
+//! The table is created by the example itself (idempotent); you only
+//! need an `examples.fdb` database. The FB4-specific columns are added
+//! in a second DDL step that is allowed to fail, so the example also
+//! runs against Firebird 3.
+//!
+
+#![allow(unused_variables, unused_mut)]
+
+use rsfbclient::{prelude::*, FbError, SimpleConnection};
+
+fn connect() -> Result<SimpleConnection, FbError> {
+    #[cfg(feature = "linking")]
+    let conn = rsfbclient::builder_native()
+        .with_dyn_link()
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    #[cfg(feature = "dynamic_loading")]
+    let conn = rsfbclient::builder_native()
+        .with_dyn_load("./fbclient.lib")
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    #[cfg(feature = "pure_rust")]
+    let conn = rsfbclient::builder_pure_rust()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?
+        .into();
+
+    Ok(conn)
+}
+
+fn main() -> Result<(), FbError> {
+    let mut conn = connect()?;
+
+    let _ = conn.execute("drop table type_probe", ());
+    conn.execute(
+        "create table type_probe (
+            c_small  smallint,
+            c_int    integer,
+            c_big    bigint,
+            c_num    numeric(18,2),
+            c_double double precision,
+            c_vc     varchar(20),
+            c_bool   boolean,
+            c_ts     timestamp
+         )",
+        (),
+    )?;
+    // Firebird 4+ types, added separately so the example runs on FB3 too
+    let fb4 = conn
+        .execute(
+            "alter table type_probe add c_i128 int128, add c_dec decfloat(34)",
+            (),
+        )
+        .is_ok();
+    conn.commit()?;
+
+    conn.execute(
+        "insert into type_probe (c_small, c_int, c_big, c_num, c_double, c_vc, c_bool, c_ts)
+         values (1, 2, 3, 90071992547409.93, 0.1, 'hello', true, current_timestamp)",
+        (),
+    )?;
+    if fb4 {
+        conn.execute(
+            "update type_probe set c_i128 = 170141183460469231731687303715884105727,
+                                   c_dec  = 1.234567890123456789012345678901234E+10",
+            (),
+        )?;
+    }
+    conn.commit()?;
+
+    // 1. The supported mappings, fetched typed
+    let (small, int, big, num, double, vc, boolean): (i64, i64, i64, f64, f64, String, bool) = conn
+        .query_first(
+            "select c_small, c_int, c_big, c_num, c_double, c_vc, c_bool from type_probe",
+            (),
+        )?
+        .unwrap();
+    println!("smallint  -> i64    : {}", small);
+    println!("integer   -> i64    : {}", int);
+    println!("bigint    -> i64    : {}", big);
+    println!(
+        "numeric   -> f64    : {}   <- one cent off: the scaled integer",
+        num
+    );
+    println!("                              9007199254740993 exceeds 2^53");
+    println!("double    -> f64    : {}", double);
+    println!("varchar   -> String : {}", vc);
+    println!("boolean   -> bool   : {}", boolean);
+
+    // The server's own text rendering keeps the cent
+    let (num_text,): (String,) = conn
+        .query_first("select cast(c_num as varchar(30)) from type_probe", ())?
+        .unwrap();
+    println!("numeric via CAST    : {}   <- exact", num_text);
+
+    // 2. The unsupported types fail at describe time...
+    if fb4 {
+        match conn.query_first::<(), (String,)>("select c_i128 from type_probe", ()) {
+            Ok(_) => println!("unexpected: INT128 fetched"),
+            Err(e) => println!("select c_i128 fails  : {}", e),
+        }
+        // ...and CAST moves the conversion server-side
+        let (i128_text, dec_text): (String, String) = conn
+            .query_first(
+                "select cast(c_i128 as varchar(50)), cast(c_dec as varchar(50)) from type_probe",
+                (),
+            )?
+            .unwrap();
+        println!("int128 via CAST     : {}", i128_text);
+        println!("decfloat via CAST   : {}", dec_text);
+    } else {
+        println!("(Firebird 3 server: INT128/DECFLOAT part skipped)");
+    }
+
+    conn.commit()?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,76 @@
 //!     .into();
 //! ```
 //!
+//! # Transactions
+//!
+//! Every [Connection](./struct.Connection.html) keeps one **default transaction**, started
+//! lazily by the first `query`/`execute` call with the configuration given at connect time
+//! (the builder's `transaction(...)`/`with_transaction(...)` options; the defaults are
+//! `ReadCommited` + record version, `Wait` without timeout, read-write). Outside of an
+//! explicit `begin_transaction`, every statement is committed automatically.
+//!
+//! Two properties of the default transaction are worth knowing:
+//!
+//! - [Connection::commit](./struct.Connection.html#method.commit) and
+//!   [Connection::rollback](./struct.Connection.html#method.rollback) are **retaining**
+//!   operations: they end the current unit of work but keep the same physical transaction
+//!   alive. Its configuration — and, for `TrIsolationLevel::Concurrency` (SNAPSHOT), the
+//!   snapshot it started with — persists for the whole life of the connection.
+//! - Because the physical transaction is reused,
+//!   [begin_transaction_config](./struct.Connection.html#method.begin_transaction_config)
+//!   only applies its configuration if the default transaction has not started yet (i.e.
+//!   before the first statement on the connection).
+//!
+//! When you need a transaction with its own isolation level, lock policy or lifetime —
+//! e.g. a SNAPSHOT reader beside a NO WAIT writer — create an explicit transaction object:
+//! [Transaction](./struct.Transaction.html) for a typed connection, or
+//! [SimpleTransaction](./struct.SimpleTransaction.html) for a
+//! [SimpleConnection](./struct.SimpleConnection.html). Explicit objects take a
+//! `TransactionConfiguration` and offer a real, consuming `commit()`/`rollback()` (plus
+//! `_retaining` variants):
+//! ```rust,ignore
+//! let snapshot = TransactionConfiguration {
+//!     isolation: TrIsolationLevel::Concurrency,
+//!     lock_resolution: TrLockResolution::NoWait,
+//!     ..TransactionConfiguration::default()
+//! };
+//! let mut tr = SimpleTransaction::new(&mut conn, snapshot)?;
+//! tr.execute("update accounts set balance = balance + 1 where id = 1", ())?;
+//! tr.commit()?; // consuming: this transaction really ends here
+//! ```
+//! See `examples/isolation_levels.rs` for the full demonstration (snapshot visibility and
+//! NO WAIT update conflicts, live).
+//!
+//! # Data type mappings
+//!
+//! Column values arrive through [SqlType](./enum.SqlType.html), which is deliberately
+//! coarse. The supported mappings:
+//!
+//! | Firebird type | Rust type |
+//! |---|---|
+//! | `SMALLINT`, `INTEGER`, `BIGINT` | `i64` (or any smaller integer type via `try_into`) |
+//! | `FLOAT`, `DOUBLE PRECISION`, `NUMERIC`, `DECIMAL` | `f64` / `f32` |
+//! | `CHAR`, `VARCHAR` | `String` (decoded with the connection charset) |
+//! | `BLOB SUB_TYPE TEXT` | `String` |
+//! | `BLOB SUB_TYPE BINARY` | `Vec<u8>` |
+//! | `DATE`, `TIME`, `TIMESTAMP` | `chrono::NaiveDate` / `NaiveTime` / `NaiveDateTime` |
+//! | `BOOLEAN` | `bool` (Firebird 3+) |
+//! | any nullable column | `Option<T>` |
+//!
+//! The sharp edges:
+//!
+//! - **`NUMERIC`/`DECIMAL` go through `f64`**: scaled values whose integer form exceeds
+//!   2^53 lose precision silently (e.g. `NUMERIC(18,2)` storing `90071992547409.93` reads
+//!   back as `90071992547409.92`). When the exact digits matter, `CAST` the column to
+//!   `VARCHAR` in SQL and parse, or keep the value in a wider text/integer form.
+//! - **Firebird 4+ types are not supported by the row reader**: selecting an `INT128`,
+//!   `DECFLOAT(16/34)`, `TIMESTAMP WITH TIME ZONE` or `TIME WITH TIME ZONE` column (or a
+//!   blob with `sub_type > 1`) fails at describe time with *"Unsupported column type"*.
+//!   `CAST` such columns to `VARCHAR`/`BIGINT`/plain `TIMESTAMP` in the SQL to move the
+//!   conversion server-side.
+//!
+//! See `examples/type_mapping.rs` for all of the above, live.
+//!
 //! # Cargo features
 //! All features can be used at the same time if needed.
 //!


### PR DESCRIPTION
Hi! We recently ported the 43 hands-on companion samples of a Firebird architecture paper to rsfbclient ([samples/rust here](https://github.com/mariuz/conceptual-architecture-for-firebird-paper/tree/master/samples/rust)) — every subsystem document now has a verified rsfbclient twin next to its C++/fb-cpp/node-firebird siblings. Along the way we collected the behaviors that surprised us, and this PR feeds the two most useful ones back as examples + documentation, per CONTRIBUTING's invitation for docs carrying Firebird knowledge.

## New examples

**`examples/isolation_levels.rs`** — explicit `SimpleTransaction` objects with `TransactionConfiguration`: SNAPSHOT vs READ COMMITTED visibility across two connections, and a `NoWait` update conflict surfacing the `-913` chain with the concurrent transaction number. The header explains *why* explicit transactions are the right tool here: `Connection::commit`/`rollback` are retaining, so the default transaction keeps its first configuration — and, under SNAPSHOT, its first snapshot — for the life of the connection. (Our first port used the default transaction with a "NoWait" config passed to `begin_transaction_config` after the first statement, and watched the update block forever under the connect-time WAIT default. Documented, in hindsight — but easy to fall into, so now it's an example.)

**`examples/type_mapping.rs`** — every supported `SqlType` mapping fetched typed, plus the two sharp edges shown live: `NUMERIC(18,2)` storing `90071992547409.93` reads back `.92` through `f64` (scaled integer past 2^53), exact via `CAST`; and INT128/DECFLOAT failing at describe time with `Unsupported column type (32752/32762)`, with the CAST-to-VARCHAR route delivering all digits. The FB4 columns are added in a separate allowed-to-fail DDL step so the example still runs against Firebird 3.

## Extended documentation

Two new chapters in the `src/lib.rs` front-page doc, between "Simple Connection/Transaction" and "Cargo features":

- **Transactions** — the default transaction's lifecycle (lazy start with the connect-time configuration, retaining commit/rollback, configuration fixed at first use, `begin_transaction_config` reusing the existing physical transaction), and when to reach for explicit `Transaction`/`SimpleTransaction` objects.
- **Data type mappings** — the supported conversions as a table, plus the f64-precision and FB4-types caveats with their workarounds.

## Verification

- Both examples run verified against Firebird 6.0 (`LI-T6.0.0.2076`, Linux aarch64, `linking` feature): snapshot holds at 100 while the other connection commits 150; the NoWait conflict raises `-913 update conflicts with concurrent update`; the INT128/DECFLOAT paths produce exactly the documented errors and CAST results.
- `cargo build --examples` clean (no new warnings), `cargo fmt --all -- --check` passes, `cargo doc` adds no new warnings.

Happy to adjust scope or wording — and if you'd like, we can follow up with issues for the sharp edges we hit that this PR only documents (e.g. `EngineVersion` stopping at V5 makes `SystemInfos::server_engine()` fail on Firebird 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
