### PR TITLE
Add a Services API (service_mgr) for the native client: server version, backup and restore with streamed verbose output

### DIFF
--- a/examples/services.rs
+++ b/examples/services.rs
@@ -1,0 +1,70 @@
+//!
+//! Rust Firebird Client
+//!
+//! Example of the Services API: server version and a verbose
+//! backup/restore round trip through the service manager — the same
+//! channel gbak uses.
+//!
+//! Needs the native client (linking or dynamic_loading feature); the
+//! pure-rust wire implementation cannot reach the service manager.
+//!
+//! All paths below are SERVER paths: the backup file is created on the
+//! server, by the server, no matter where this program runs.
+//!
+
+#![allow(unused_variables, unused_mut)]
+
+fn main() {
+    #[cfg(any(feature = "linking", feature = "dynamic_loading"))]
+    example::run().unwrap();
+
+    #[cfg(not(any(feature = "linking", feature = "dynamic_loading")))]
+    println!(
+        "The Services API needs the native client (enable the linking or dynamic_loading feature)"
+    );
+}
+
+#[cfg(any(feature = "linking", feature = "dynamic_loading"))]
+mod example {
+    use rsfbclient::services::{ServiceManager, SvcBackupOptions, SvcRestoreOptions};
+    use rsfbclient::FbError;
+
+    pub fn run() -> Result<(), FbError> {
+        #[cfg(feature = "linking")]
+        let mut svc = ServiceManager::builder()
+            .host("localhost")
+            .user("SYSDBA")
+            .pass("masterkey")
+            .attach()?;
+
+        #[cfg(all(feature = "dynamic_loading", not(feature = "linking")))]
+        let mut svc = ServiceManager::builder()
+            .host("localhost")
+            .user("SYSDBA")
+            .pass("masterkey")
+            .with_dyn_load("./fbclient.lib")
+            .attach()?;
+
+        println!("server version: {}", svc.server_version()?);
+
+        // Verbose backup: the gbak log streams through the closure
+        // while the backup runs on the server.
+        println!("backing up examples.fdb:");
+        svc.backup_with_output(
+            "examples.fdb",
+            "examples.fbk",
+            SvcBackupOptions::default(),
+            |line| println!("  {}", line),
+        )?;
+
+        // Restore to a new database, quietly.
+        let opts = SvcRestoreOptions {
+            replace: true,
+            ..SvcRestoreOptions::default()
+        };
+        svc.restore("examples.fbk", "examples_restored.fdb", opts)?;
+        println!("restored examples.fbk -> examples_restored.fdb");
+
+        Ok(())
+    }
+}

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -606,6 +606,41 @@ parse_functions! {
             arg4: *mut ::std::os::raw::c_void,
         ) -> ISC_STATUS;
     }
+    extern "C" {
+        pub fn isc_service_attach(
+            arg1: *mut ISC_STATUS,
+            arg2: ::std::os::raw::c_ushort,
+            arg3: *const ISC_SCHAR,
+            arg4: *mut isc_svc_handle,
+            arg5: ::std::os::raw::c_ushort,
+            arg6: *const ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_detach(arg1: *mut ISC_STATUS, arg2: *mut isc_svc_handle) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_query(
+            arg1: *mut ISC_STATUS,
+            arg2: *mut isc_svc_handle,
+            arg3: *mut isc_resv_handle,
+            arg4: ::std::os::raw::c_ushort,
+            arg5: *const ISC_SCHAR,
+            arg6: ::std::os::raw::c_ushort,
+            arg7: *const ISC_SCHAR,
+            arg8: ::std::os::raw::c_ushort,
+            arg9: *mut ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_start(
+            arg1: *mut ISC_STATUS,
+            arg2: *mut isc_svc_handle,
+            arg3: *mut isc_resv_handle,
+            arg4: ::std::os::raw::c_ushort,
+            arg5: *const ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
     // extern "C" {
     //     pub fn isc_start_transaction(
     //         arg1: *mut ISC_STATUS,

--- a/rsfbclient-native/src/ibase.rs
+++ b/rsfbclient-native/src/ibase.rs
@@ -606,41 +606,6 @@ parse_functions! {
             arg4: *mut ::std::os::raw::c_void,
         ) -> ISC_STATUS;
     }
-    extern "C" {
-        pub fn isc_service_attach(
-            arg1: *mut ISC_STATUS,
-            arg2: ::std::os::raw::c_ushort,
-            arg3: *const ISC_SCHAR,
-            arg4: *mut isc_svc_handle,
-            arg5: ::std::os::raw::c_ushort,
-            arg6: *const ISC_SCHAR,
-        ) -> ISC_STATUS;
-    }
-    extern "C" {
-        pub fn isc_service_detach(arg1: *mut ISC_STATUS, arg2: *mut isc_svc_handle) -> ISC_STATUS;
-    }
-    extern "C" {
-        pub fn isc_service_query(
-            arg1: *mut ISC_STATUS,
-            arg2: *mut isc_svc_handle,
-            arg3: *mut isc_resv_handle,
-            arg4: ::std::os::raw::c_ushort,
-            arg5: *const ISC_SCHAR,
-            arg6: ::std::os::raw::c_ushort,
-            arg7: *const ISC_SCHAR,
-            arg8: ::std::os::raw::c_ushort,
-            arg9: *mut ISC_SCHAR,
-        ) -> ISC_STATUS;
-    }
-    extern "C" {
-        pub fn isc_service_start(
-            arg1: *mut ISC_STATUS,
-            arg2: *mut isc_svc_handle,
-            arg3: *mut isc_resv_handle,
-            arg4: ::std::os::raw::c_ushort,
-            arg5: *const ISC_SCHAR,
-        ) -> ISC_STATUS;
-    }
     // extern "C" {
     //     pub fn isc_start_transaction(
     //         arg1: *mut ISC_STATUS,
@@ -1238,41 +1203,41 @@ parse_functions! {
     // extern "C" {
     //     pub fn isc_baddress_s(arg1: *const ISC_SCHAR, arg2: *mut usize);
     // }
-    // extern "C" {
-    //     pub fn isc_service_attach(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: ::std::os::raw::c_ushort,
-    //         arg3: *const ISC_SCHAR,
-    //         arg4: *mut isc_svc_handle,
-    //         arg5: ::std::os::raw::c_ushort,
-    //         arg6: *const ISC_SCHAR,
-    //     ) -> ISC_STATUS;
-    // }
-    // extern "C" {
-    //     pub fn isc_service_detach(arg1: *mut ISC_STATUS, arg2: *mut isc_svc_handle) -> ISC_STATUS;
-    // }
-    // extern "C" {
-    //     pub fn isc_service_query(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: *mut isc_svc_handle,
-    //         arg3: *mut isc_resv_handle,
-    //         arg4: ::std::os::raw::c_ushort,
-    //         arg5: *const ISC_SCHAR,
-    //         arg6: ::std::os::raw::c_ushort,
-    //         arg7: *const ISC_SCHAR,
-    //         arg8: ::std::os::raw::c_ushort,
-    //         arg9: *mut ISC_SCHAR,
-    //     ) -> ISC_STATUS;
-    // }
-    // extern "C" {
-    //     pub fn isc_service_start(
-    //         arg1: *mut ISC_STATUS,
-    //         arg2: *mut isc_svc_handle,
-    //         arg3: *mut isc_resv_handle,
-    //         arg4: ::std::os::raw::c_ushort,
-    //         arg5: *const ISC_SCHAR,
-    //     ) -> ISC_STATUS;
-    // }
+    extern "C" {
+        pub fn isc_service_attach(
+            arg1: *mut ISC_STATUS,
+            arg2: ::std::os::raw::c_ushort,
+            arg3: *const ISC_SCHAR,
+            arg4: *mut isc_svc_handle,
+            arg5: ::std::os::raw::c_ushort,
+            arg6: *const ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_detach(arg1: *mut ISC_STATUS, arg2: *mut isc_svc_handle) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_query(
+            arg1: *mut ISC_STATUS,
+            arg2: *mut isc_svc_handle,
+            arg3: *mut isc_resv_handle,
+            arg4: ::std::os::raw::c_ushort,
+            arg5: *const ISC_SCHAR,
+            arg6: ::std::os::raw::c_ushort,
+            arg7: *const ISC_SCHAR,
+            arg8: ::std::os::raw::c_ushort,
+            arg9: *mut ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
+    extern "C" {
+        pub fn isc_service_start(
+            arg1: *mut ISC_STATUS,
+            arg2: *mut isc_svc_handle,
+            arg3: *mut isc_resv_handle,
+            arg4: ::std::os::raw::c_ushort,
+            arg5: *const ISC_SCHAR,
+        ) -> ISC_STATUS;
+    }
     // extern "C" {
     //     pub fn fb_shutdown(
     //         arg1: ::std::os::raw::c_uint,

--- a/rsfbclient-native/src/lib.rs
+++ b/rsfbclient-native/src/lib.rs
@@ -4,6 +4,7 @@ mod connection;
 pub(crate) mod ibase;
 pub(crate) mod params;
 pub(crate) mod row;
+pub mod services;
 pub(crate) mod status;
 pub(crate) mod varchar;
 pub(crate) mod xsqlda;
@@ -11,3 +12,5 @@ pub(crate) mod xsqlda;
 pub use connection::{NativeFbAttachmentConfig, NativeFbClient, RemoteConfig};
 
 pub use connection::{DynLink, DynLoad, LinkageMarker};
+
+pub use services::NativeServiceManager;

--- a/rsfbclient-native/src/services.rs
+++ b/rsfbclient-native/src/services.rs
@@ -1,0 +1,145 @@
+//! Native service manager: a thin, safe wrapper over the
+//! `isc_service_attach` / `isc_service_start` / `isc_service_query` /
+//! `isc_service_detach` client entry points.
+//!
+//! This is the low-level half of the Services API: it owns the service
+//! handle and moves parameter blocks and reply buffers across the FFI
+//! boundary. The user-facing API (SPB construction, backup/restore
+//! actions, reply parsing) lives in the `rsfbclient` crate's `services`
+//! module, which drives this one.
+
+use crate::{connection::LinkageMarker, ibase, ibase::IBase, status::Status};
+use rsfbclient_core::FbError;
+
+/// A native attachment to a Firebird server's service manager
+/// (`service_mgr`).
+///
+/// Detaches automatically on drop.
+pub struct NativeServiceManager<T: LinkageMarker> {
+    ibase: T::L,
+    status: Status,
+    handle: ibase::isc_svc_handle,
+}
+
+#[cfg(feature = "linking")]
+impl NativeServiceManager<crate::connection::DynLink> {
+    /// Attach to `service_mgr` via the dynamically linked fbclient.
+    pub fn attach_dyn_link(host: &str, port: u16, attach_spb: &[u8]) -> Result<Self, FbError> {
+        Self::attach(ibase::IBaseLinking, host, port, attach_spb)
+    }
+}
+
+#[cfg(feature = "dynamic_loading")]
+impl NativeServiceManager<crate::connection::DynLoad> {
+    /// Attach to `service_mgr`, loading the fbclient library from
+    /// `lib_path` first.
+    pub fn attach_dyn_load(
+        lib_path: &str,
+        host: &str,
+        port: u16,
+        attach_spb: &[u8],
+    ) -> Result<Self, FbError> {
+        let lib = ibase::IBaseDynLoading::with_client(lib_path.as_ref())
+            .map_err(|e| FbError::from(e.to_string()))?;
+        Self::attach(lib, host, port, attach_spb)
+    }
+}
+
+impl<T: LinkageMarker> NativeServiceManager<T> {
+    /// Attach to `service_mgr` on `host:port` with the supplied
+    /// attach-SPB (credentials).
+    ///
+    /// `ibase` is the loaded/linked client library, obtained the same
+    /// way the connection builders obtain theirs.
+    fn attach(ibase: T::L, host: &str, port: u16, attach_spb: &[u8]) -> Result<Self, FbError> {
+        let mut status: Status = Default::default();
+        let mut handle: ibase::isc_svc_handle = 0;
+
+        let conn_string = format!("{}/{}:service_mgr", host, port);
+
+        unsafe {
+            if ibase.isc_service_attach()(
+                &mut status[0],
+                conn_string.len() as u16,
+                conn_string.as_ptr() as *const _,
+                &mut handle,
+                attach_spb.len() as u16,
+                attach_spb.as_ptr() as *const _,
+            ) != 0
+            {
+                return Err(status.as_error(&ibase));
+            }
+        }
+
+        debug_assert_ne!(handle, 0);
+
+        Ok(Self {
+            ibase,
+            status,
+            handle,
+        })
+    }
+
+    /// Start a service action (`isc_action_svc_*` request block).
+    pub fn start(&mut self, request: &[u8]) -> Result<(), FbError> {
+        unsafe {
+            if self.ibase.isc_service_start()(
+                &mut self.status[0],
+                &mut self.handle,
+                std::ptr::null_mut(),
+                request.len() as u16,
+                request.as_ptr() as *const _,
+            ) != 0
+            {
+                return Err(self.status.as_error(&self.ibase));
+            }
+        }
+        Ok(())
+    }
+
+    /// Run one information request against the service, filling `buffer`
+    /// with the reply clumplets.
+    pub fn query(
+        &mut self,
+        send_items: &[u8],
+        receive_items: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), FbError> {
+        unsafe {
+            if self.ibase.isc_service_query()(
+                &mut self.status[0],
+                &mut self.handle,
+                std::ptr::null_mut(),
+                send_items.len() as u16,
+                send_items.as_ptr() as *const _,
+                receive_items.len() as u16,
+                receive_items.as_ptr() as *const _,
+                buffer.len() as u16,
+                buffer.as_mut_ptr() as *mut _,
+            ) != 0
+            {
+                return Err(self.status.as_error(&self.ibase));
+            }
+        }
+        Ok(())
+    }
+
+    /// Detach from the service manager. Called automatically on drop.
+    pub fn detach(&mut self) -> Result<(), FbError> {
+        unsafe {
+            if self.handle != 0
+                && self.ibase.isc_service_detach()(&mut self.status[0], &mut self.handle) != 0
+            {
+                return Err(self.status.as_error(&self.ibase));
+            }
+        }
+        self.handle = 0;
+        Ok(())
+    }
+}
+
+impl<T: LinkageMarker> Drop for NativeServiceManager<T> {
+    fn drop(&mut self) {
+        self.detach().ok();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,32 @@
 //!     .into();
 //! ```
 //!
+//! # Services API
+//!
+//! With the native client (`linking` or `dynamic_loading` features) the
+//! [services](./services/index.html) module can attach to a server's *service
+//! manager* — the administration channel that `gbak` and the other command-line
+//! tools use — to query the server version and run backups and restores, with
+//! the verbose `gbak` log streamed back line by line while the action runs:
+//!
+//! ```rust,ignore
+//! use rsfbclient::services::{ServiceManager, SvcBackupOptions};
+//!
+//! let mut svc = ServiceManager::builder()
+//!     .host("localhost")
+//!     .user("SYSDBA")
+//!     .pass("masterkey")
+//!     .attach()?;
+//! println!("{}", svc.server_version()?);
+//! svc.backup_with_output("/data/db.fdb", "/data/db.fbk",
+//!     SvcBackupOptions::default(), |line| println!("{}", line))?;
+//! ```
+//!
+//! All paths given to service actions are **server** paths: the backup file is
+//! written on the server, by the server. The pure-rust wire implementation does
+//! not carry the service protocol, so this module needs one of the native
+//! features.
+//!
 //! # Cargo features
 //! All features can be used at the same time if needed.
 //!
@@ -92,6 +118,9 @@ mod query;
 mod statement;
 mod transaction;
 mod utils;
+
+#[cfg(feature = "native_client")]
+pub mod services;
 
 pub use crate::{
     connection::{Connection, ConnectionConfiguration, FirebirdClientFactory, SimpleConnection},

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,0 +1,394 @@
+//!
+//! Firebird Services API: server-side administration through the
+//! `service_mgr` endpoint — the same channel the `gbak` and
+//! `fbtracemgr` tools use.
+//!
+//! The Services API is separate from the SQL protocol: you attach to a
+//! *service manager* rather than to a database, start an *action*
+//! (backup, restore, ...) described by a service parameter block, and
+//! then drain the action's output line by line with information
+//! requests. Everything happens **on the server**: the database paths
+//! and backup-file paths passed to [ServiceManager::backup] and
+//! [ServiceManager::restore] are server paths, and the files they
+//! produce are owned by the server process.
+//!
+//! Only the NATIVE client (`linking` or `dynamic_loading` features)
+//! can speak to the service manager — the service protocol is carried
+//! by dedicated opcodes that the pure-rust wire implementation does not
+//! implement, so this module is not available with only the
+//! `pure_rust` feature.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use rsfbclient::services::ServiceManager;
+//!
+//! let mut svc = ServiceManager::builder()
+//!     .host("localhost")
+//!     .user("SYSDBA")
+//!     .pass("masterkey")
+//!     .attach()?;
+//!
+//! println!("server version: {}", svc.server_version()?);
+//!
+//! // Verbose backup: gbak's log arrives through the closure, one
+//! // line at a time, while the backup runs.
+//! svc.backup_with_output(
+//!     "/data/mydb.fdb",              // server path!
+//!     "/data/mydb.fbk",              // server path!
+//!     SvcBackupOptions::default(),
+//!     |line| println!("gbak: {}", line),
+//! )?;
+//!
+//! // Restore over an existing database.
+//! let opts = SvcRestoreOptions {
+//!     replace: true,
+//!     ..SvcRestoreOptions::default()
+//! };
+//! svc.restore("/data/mydb.fbk", "/data/mydb-copy.fdb", opts)?;
+//! ```
+
+use rsfbclient_core::{ibase, FbError};
+
+#[cfg(feature = "linking")]
+use rsfbclient_native::DynLink;
+#[cfg(feature = "dynamic_loading")]
+use rsfbclient_native::DynLoad;
+use rsfbclient_native::NativeServiceManager;
+
+/// Options for [ServiceManager::backup] /
+/// [ServiceManager::backup_with_output]. All default to `false`,
+/// matching `gbak`'s defaults.
+#[derive(Clone, Copy, Default)]
+pub struct SvcBackupOptions {
+    /// Back up metadata only, no table data (`gbak -m`)
+    pub metadata_only: bool,
+    /// Ignore checksum errors while reading (`gbak -ig`)
+    pub ignore_checksums: bool,
+    /// Ignore in-limbo transactions (`gbak -l`)
+    pub ignore_limbo: bool,
+    /// Do not run garbage collection during the backup (`gbak -g`);
+    /// commonly enabled for faster backups of busy databases
+    pub no_garbage_collect: bool,
+}
+
+/// Options for [ServiceManager::restore] /
+/// [ServiceManager::restore_with_output].
+#[derive(Clone, Copy, Default)]
+pub struct SvcRestoreOptions {
+    /// Replace the target database if it already exists (`gbak -rep`).
+    /// When `false` (the default) the restore fails if the target
+    /// exists — the safe behaviour, same as `gbak -c`.
+    pub replace: bool,
+    /// Page size of the restored database (`gbak -p`); `None` keeps
+    /// the page size recorded in the backup
+    pub page_size: Option<u32>,
+}
+
+/// Builder for a [ServiceManager] attachment.
+///
+/// Mirrors the connection builders in miniature: host/port/user/pass
+/// plus the choice between the dynamically linked fbclient (the
+/// default when the `linking` feature is on) and a dynamically loaded
+/// one ([ServiceManagerBuilder::with_dyn_load]).
+#[derive(Clone)]
+pub struct ServiceManagerBuilder {
+    host: String,
+    port: u16,
+    user: String,
+    pass: String,
+    lib_path: Option<String>,
+}
+
+impl Default for ServiceManagerBuilder {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_string(),
+            port: 3050,
+            user: "SYSDBA".to_string(),
+            pass: "masterkey".to_string(),
+            lib_path: None,
+        }
+    }
+}
+
+impl ServiceManagerBuilder {
+    /// Hostname or IP of the server. Default: `localhost`
+    pub fn host<S: Into<String>>(&mut self, host: S) -> &mut Self {
+        self.host = host.into();
+        self
+    }
+
+    /// TCP port of the server. Default: `3050`
+    pub fn port(&mut self, port: u16) -> &mut Self {
+        self.port = port;
+        self
+    }
+
+    /// User name. Default: `SYSDBA`
+    pub fn user<S: Into<String>>(&mut self, user: S) -> &mut Self {
+        self.user = user.into();
+        self
+    }
+
+    /// Password. Default: `masterkey`
+    pub fn pass<S: Into<String>>(&mut self, pass: S) -> &mut Self {
+        self.pass = pass.into();
+        self
+    }
+
+    /// Load the fbclient library from this path at runtime instead of
+    /// using the dynamically linked one (requires the
+    /// `dynamic_loading` feature).
+    pub fn with_dyn_load<S: Into<String>>(&mut self, lib_path: S) -> &mut Self {
+        self.lib_path = Some(lib_path.into());
+        self
+    }
+
+    /// Attach to the server's service manager.
+    pub fn attach(&self) -> Result<ServiceManager, FbError> {
+        let spb = build_attach_spb(&self.user, &self.pass);
+
+        match &self.lib_path {
+            None => {
+                #[cfg(feature = "linking")]
+                {
+                    let inner = NativeServiceManager::<DynLink>::attach_dyn_link(
+                        &self.host, self.port, &spb,
+                    )?;
+                    Ok(ServiceManager {
+                        inner: SvcContainer::Linking(inner),
+                    })
+                }
+                #[cfg(not(feature = "linking"))]
+                Err(FbError::from(
+                    "The 'linking' feature is disabled; use with_dyn_load() to load a client library by path",
+                ))
+            }
+            Some(lib_path) => {
+                #[cfg(feature = "dynamic_loading")]
+                {
+                    let inner = NativeServiceManager::<DynLoad>::attach_dyn_load(
+                        lib_path, &self.host, self.port, &spb,
+                    )?;
+                    Ok(ServiceManager {
+                        inner: SvcContainer::DynLoad(inner),
+                    })
+                }
+                #[cfg(not(feature = "dynamic_loading"))]
+                {
+                    let _ = lib_path;
+                    Err(FbError::from(
+                        "with_dyn_load() requires the 'dynamic_loading' feature",
+                    ))
+                }
+            }
+        }
+    }
+}
+
+enum SvcContainer {
+    #[cfg(feature = "linking")]
+    Linking(NativeServiceManager<DynLink>),
+    #[cfg(feature = "dynamic_loading")]
+    DynLoad(NativeServiceManager<DynLoad>),
+}
+
+/// An attachment to a Firebird server's service manager.
+///
+/// Obtained through [ServiceManager::builder]. Detaches on drop.
+pub struct ServiceManager {
+    inner: SvcContainer,
+}
+
+impl ServiceManager {
+    /// Start building a service manager attachment.
+    pub fn builder() -> ServiceManagerBuilder {
+        ServiceManagerBuilder::default()
+    }
+
+    /// The server version string, e.g. `LI-V4.0.2.2816 Firebird 4.0`.
+    pub fn server_version(&mut self) -> Result<String, FbError> {
+        let receive = [ibase::isc_info_svc_server_version as u8];
+        let mut buffer = [0u8; 1024];
+        self.query(&[], &receive, &mut buffer)?;
+
+        if buffer[0] != ibase::isc_info_svc_server_version as u8 {
+            return Err(FbError::from("Unexpected service version reply"));
+        }
+        let len = u16::from_le_bytes([buffer[1], buffer[2]]) as usize;
+        Ok(String::from_utf8_lossy(&buffer[3..3 + len]).to_string())
+    }
+
+    /// Run a `gbak`-style backup of `db_name` (a SERVER path) into
+    /// `backup_file` (also a SERVER path), blocking until it finishes.
+    ///
+    /// The service's output is drained and discarded; use
+    /// [ServiceManager::backup_with_output] to receive it.
+    pub fn backup(
+        &mut self,
+        db_name: &str,
+        backup_file: &str,
+        options: SvcBackupOptions,
+    ) -> Result<(), FbError> {
+        self.backup_with_output(db_name, backup_file, options, |_| {})
+    }
+
+    /// Like [ServiceManager::backup], but streams the verbose `gbak`
+    /// log through `on_line`, one line at a time, while the backup
+    /// runs.
+    pub fn backup_with_output<F: FnMut(&str)>(
+        &mut self,
+        db_name: &str,
+        backup_file: &str,
+        options: SvcBackupOptions,
+        on_line: F,
+    ) -> Result<(), FbError> {
+        let mut flags = 0u32;
+        if options.metadata_only {
+            flags |= ibase::isc_spb_bkp_metadata_only;
+        }
+        if options.ignore_checksums {
+            flags |= ibase::isc_spb_bkp_ignore_checksums;
+        }
+        if options.ignore_limbo {
+            flags |= ibase::isc_spb_bkp_ignore_limbo;
+        }
+        if options.no_garbage_collect {
+            flags |= ibase::isc_spb_bkp_no_garbage_collect;
+        }
+
+        let mut req = vec![ibase::isc_action_svc_backup as u8];
+        push_string_arg(&mut req, ibase::isc_spb_dbname as u8, db_name);
+        push_string_arg(&mut req, ibase::isc_spb_bkp_file as u8, backup_file);
+        push_u32_arg(&mut req, ibase::isc_spb_options as u8, flags);
+        req.push(ibase::isc_spb_verbose as u8);
+
+        self.start(&req)?;
+        self.drain_output(on_line)
+    }
+
+    /// Restore `backup_file` (a SERVER path) into `db_name` (also a
+    /// SERVER path), blocking until it finishes.
+    ///
+    /// With the default options the restore fails if `db_name` already
+    /// exists; set [SvcRestoreOptions::replace] to overwrite it.
+    pub fn restore(
+        &mut self,
+        backup_file: &str,
+        db_name: &str,
+        options: SvcRestoreOptions,
+    ) -> Result<(), FbError> {
+        self.restore_with_output(backup_file, db_name, options, |_| {})
+    }
+
+    /// Like [ServiceManager::restore], but streams the verbose `gbak`
+    /// log through `on_line`.
+    pub fn restore_with_output<F: FnMut(&str)>(
+        &mut self,
+        backup_file: &str,
+        db_name: &str,
+        options: SvcRestoreOptions,
+        on_line: F,
+    ) -> Result<(), FbError> {
+        let flags = if options.replace {
+            ibase::isc_spb_res_replace
+        } else {
+            ibase::isc_spb_res_create
+        };
+
+        let mut req = vec![ibase::isc_action_svc_restore as u8];
+        push_string_arg(&mut req, ibase::isc_spb_bkp_file as u8, backup_file);
+        push_string_arg(&mut req, ibase::isc_spb_dbname as u8, db_name);
+        push_u32_arg(&mut req, ibase::isc_spb_options as u8, flags);
+        if let Some(page_size) = options.page_size {
+            push_u32_arg(&mut req, ibase::isc_spb_res_page_size as u8, page_size);
+        }
+        req.push(ibase::isc_spb_verbose as u8);
+
+        self.start(&req)?;
+        self.drain_output(on_line)
+    }
+
+    /// Detach from the service manager. Also called automatically on
+    /// drop.
+    pub fn detach(&mut self) -> Result<(), FbError> {
+        match &mut self.inner {
+            #[cfg(feature = "linking")]
+            SvcContainer::Linking(s) => s.detach(),
+            #[cfg(feature = "dynamic_loading")]
+            SvcContainer::DynLoad(s) => s.detach(),
+        }
+    }
+
+    fn start(&mut self, request: &[u8]) -> Result<(), FbError> {
+        match &mut self.inner {
+            #[cfg(feature = "linking")]
+            SvcContainer::Linking(s) => s.start(request),
+            #[cfg(feature = "dynamic_loading")]
+            SvcContainer::DynLoad(s) => s.start(request),
+        }
+    }
+
+    fn query(&mut self, send: &[u8], receive: &[u8], buffer: &mut [u8]) -> Result<(), FbError> {
+        match &mut self.inner {
+            #[cfg(feature = "linking")]
+            SvcContainer::Linking(s) => s.query(send, receive, buffer),
+            #[cfg(feature = "dynamic_loading")]
+            SvcContainer::DynLoad(s) => s.query(send, receive, buffer),
+        }
+    }
+
+    /// Poll `isc_info_svc_line` until the running action's output is
+    /// exhausted — the same loop `gbak -se` runs. Each drained line is
+    /// handed to `on_line`.
+    fn drain_output<F: FnMut(&str)>(&mut self, mut on_line: F) -> Result<(), FbError> {
+        let receive = [ibase::isc_info_svc_line as u8];
+        loop {
+            let mut buffer = [0u8; 4096];
+            self.query(&[], &receive, &mut buffer)?;
+
+            if buffer[0] != ibase::isc_info_svc_line as u8 {
+                // isc_info_end or anything unexpected: the action is over
+                return Ok(());
+            }
+            let len = u16::from_le_bytes([buffer[1], buffer[2]]) as usize;
+            if len == 0 {
+                // an empty line ends the stream
+                return Ok(());
+            }
+            on_line(&String::from_utf8_lossy(&buffer[3..3 + len]));
+        }
+    }
+}
+
+/// Version-2 attach SPB: version tags + credentials, each argument a
+/// tag byte, a ONE-byte length and the bytes.
+fn build_attach_spb(user: &str, pass: &str) -> Vec<u8> {
+    let mut spb = vec![
+        ibase::isc_spb_version as u8,
+        ibase::isc_spb_current_version as u8,
+    ];
+    spb.push(ibase::isc_spb_user_name as u8);
+    spb.push(user.len() as u8);
+    spb.extend_from_slice(user.as_bytes());
+    spb.push(ibase::isc_spb_password as u8);
+    spb.push(pass.len() as u8);
+    spb.extend_from_slice(pass.as_bytes());
+    spb
+}
+
+/// Start-request string argument: tag, TWO-byte little-endian length,
+/// bytes. (Attach and start blocks use different length encodings —
+/// one of the classic Services API traps.)
+fn push_string_arg(req: &mut Vec<u8>, tag: u8, value: &str) {
+    req.push(tag);
+    req.extend_from_slice(&(value.len() as u16).to_le_bytes());
+    req.extend_from_slice(value.as_bytes());
+}
+
+/// Start-request numeric argument: tag + four-byte little-endian value.
+fn push_u32_arg(req: &mut Vec<u8>, tag: u8, value: u32) {
+    req.push(tag);
+    req.extend_from_slice(&value.to_le_bytes());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -117,4 +117,5 @@ mod connection;
 mod database;
 mod params;
 mod row;
+mod services;
 mod transaction;

--- a/src/tests/services.rs
+++ b/src/tests/services.rs
@@ -1,0 +1,177 @@
+//!
+//! Rust Firebird Client
+//!
+//! Services API tests
+//!
+//! The Services API needs the native client and a remote server, so
+//! unlike the other test modules these are plain feature-gated tests
+//! rather than mk_tests_default! copies: there is exactly one service
+//! manager implementation per native linkage, and the pure-rust client
+//! cannot reach it at all.
+//!
+//! Note that every path handed to a service action is a SERVER path;
+//! the tests use relative paths, which the server resolves against its
+//! own environment — the same convention the database tests use.
+
+#![cfg(all(
+    any(feature = "linking", feature = "dynamic_loading"),
+    not(feature = "embedded_tests")
+))]
+
+use crate::services::*;
+use crate::*;
+
+#[cfg(feature = "linking")]
+fn svc() -> Result<ServiceManager, FbError> {
+    ServiceManager::builder()
+        .host("localhost")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .attach()
+}
+
+#[cfg(all(feature = "dynamic_loading", not(feature = "linking")))]
+fn svc() -> Result<ServiceManager, FbError> {
+    #[cfg(target_os = "linux")]
+    let libfbclient = "libfbclient.so";
+    #[cfg(target_os = "windows")]
+    let libfbclient = "fbclient.dll";
+    #[cfg(target_os = "macos")]
+    let libfbclient = "libfbclient.dylib";
+
+    ServiceManager::builder()
+        .host("localhost")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .with_dyn_load(libfbclient)
+        .attach()
+}
+
+#[cfg(feature = "linking")]
+fn cbuilder() -> builders::NativeConnectionBuilder<builders::DynLink, builders::ConnRemote> {
+    crate::builder_native().with_dyn_link().with_remote()
+}
+
+#[cfg(all(feature = "dynamic_loading", not(feature = "linking")))]
+fn cbuilder() -> builders::NativeConnectionBuilder<builders::DynLoad, builders::ConnRemote> {
+    #[cfg(target_os = "linux")]
+    let libfbclient = "libfbclient.so";
+    #[cfg(target_os = "windows")]
+    let libfbclient = "fbclient.dll";
+    #[cfg(target_os = "macos")]
+    let libfbclient = "libfbclient.dylib";
+
+    crate::builder_native()
+        .with_dyn_load(libfbclient)
+        .with_remote()
+}
+
+#[test]
+fn server_version() -> Result<(), FbError> {
+    let mut svc = svc()?;
+    let version = svc.server_version()?;
+
+    // e.g. "LI-V4.0.2.2816 Firebird 4.0" — don't tie the test to a
+    // specific version, only to the response being a plausible
+    // version string.
+    assert!(!version.is_empty(), "server version came back empty");
+    assert!(
+        version.contains("Firebird") || version.chars().any(|c| c.is_ascii_digit()),
+        "unexpected server version string: {}",
+        version
+    );
+
+    Ok(())
+}
+
+#[test]
+fn backup_restore_roundtrip() -> Result<(), FbError> {
+    let db = "test_svc_roundtrip.fdb";
+    let fbk = "test_svc_roundtrip.fbk";
+    let restored = "test_svc_roundtrip_restored.fdb";
+
+    // 1. a database with known content
+    {
+        let mut conn = cbuilder()
+            .db_name(db)
+            .user("SYSDBA")
+            .pass("masterkey")
+            .connect()
+            .or_else(|_| {
+                cbuilder()
+                    .db_name(db)
+                    .user("SYSDBA")
+                    .pass("masterkey")
+                    .create_database()
+            })?;
+        let _ = conn.execute("drop table svc_probe", ());
+        conn.execute("create table svc_probe (id int, name varchar(20))", ())?;
+        conn.execute("insert into svc_probe values (1, 'alpha')", ())?;
+        conn.execute("insert into svc_probe values (2, 'beta')", ())?;
+        conn.commit()?;
+        conn.close()?;
+    }
+
+    // 2. verbose backup: the gbak log must actually stream
+    let mut svc = svc()?;
+    let mut lines = 0usize;
+    svc.backup_with_output(db, fbk, SvcBackupOptions::default(), |_line| lines += 1)?;
+    assert!(lines > 0, "verbose backup produced no output lines");
+
+    // 3. restore to a new name (replace, so reruns are stable)
+    let opts = SvcRestoreOptions {
+        replace: true,
+        ..SvcRestoreOptions::default()
+    };
+    svc.restore(fbk, restored, opts)?;
+    svc.detach()?;
+
+    // 4. the restored copy has the data
+    let mut conn = cbuilder()
+        .db_name(restored)
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
+    let rows: Vec<(i32, String)> = conn.query("select id, name from svc_probe order by id", ())?;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (1, "alpha".to_string()));
+    assert_eq!(rows[1], (2, "beta".to_string()));
+    conn.drop_database()?;
+
+    Ok(())
+}
+
+#[test]
+fn restore_without_replace_fails_on_existing() -> Result<(), FbError> {
+    let db = "test_svc_noreplace.fdb";
+    let fbk = "test_svc_noreplace.fbk";
+
+    {
+        let conn = cbuilder()
+            .db_name(db)
+            .user("SYSDBA")
+            .pass("masterkey")
+            .connect()
+            .or_else(|_| {
+                cbuilder()
+                    .db_name(db)
+                    .user("SYSDBA")
+                    .pass("masterkey")
+                    .create_database()
+            })?;
+        conn.close()?;
+    }
+
+    let mut svc = svc()?;
+    svc.backup(db, fbk, SvcBackupOptions::default())?;
+
+    // restoring over the still-existing source without replace must
+    // fail — the isc_spb_res_create semantics
+    let result = svc.restore(fbk, db, SvcRestoreOptions::default());
+    assert!(
+        result.is_err(),
+        "restore without replace over an existing database should fail"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This implements the missing Services API for the native client — the gap we hit hardest while porting 43 Firebird architecture-paper samples to rsfbclient ([context](https://github.com/mariuz/conceptual-architecture-for-firebird-paper/tree/master/samples/rust)): the backup sample had to shell out to `gbak`, and the trace sample was the only twin across five language families that could not run its demonstration at all.

Per CONTRIBUTING this is API-sized, so treat the PR as a concrete proposal — happy to reshape the API, split it, or move parts behind discussion in an issue if you prefer that flow.

## What it adds

**`rsfbclient-native`**
- Activates the `isc_service_attach` / `isc_service_start` / `isc_service_query` / `isc_service_detach` bindings that were already present (commented out) in `ibase.rs`.
- A new `services` module with `NativeServiceManager<T: LinkageMarker>`: a thin safe wrapper owning the service handle — per-linkage constructors (`attach_dyn_link` / `attach_dyn_load`), `start`/`query`/`detach`, detach-on-drop.

**`rsfbclient`** (behind the existing `native_client` feature)
- `services::ServiceManager` with a small builder (`host`/`port`/`user`/`pass`, optional `with_dyn_load(path)`; runtime dispatch between linkages like `SimpleConnection`, to avoid duplicating the connection builders' typestate).
- `server_version()`, `backup`/`restore` with typed option structs (`SvcBackupOptions`: metadata_only, ignore_checksums, ignore_limbo, no_garbage_collect; `SvcRestoreOptions`: replace, page_size), and `*_with_output` variants that stream the verbose `gbak` log line by line **while the action runs** — the same `isc_info_svc_line` polling loop `gbak -se` uses.
- SPB construction lives in two small documented helpers, because the Services API's classic trap is that the attach block uses one-byte lengths while start-request blocks use two-byte little-endian lengths.
- Extensive rustdoc: a front-page "Services API" chapter plus full module docs, stressing that every action path is a **server** path, and why `pure_rust` cannot reach the service manager (its wire implementation doesn't carry the service opcodes).
- `examples/services.rs` in the standard example shape.

## Tests

`src/tests/services.rs` (native + remote only, plain feature-gated rather than `mk_tests_default!` since there is no per-backend matrix for services):
- `server_version` returns a plausible version string.
- `backup_restore_roundtrip`: creates a database with known rows, runs a **verbose** backup (asserting the log actually streams), restores under a new name, and verifies the rows in the restored copy, then drops it.
- `restore_without_replace_fails_on_existing`: the `isc_spb_res_create` safety semantics.

## Verification

- All three new tests pass against Firebird 6.0 (`LI-T6.0.0.2076`, Linux aarch64, `linking` feature): `test result: ok. 3 passed` (services filter); the example streams the real gbak log (`gbak:readied database ... gbak:creating file ...`).
- No regressions: the full `cargo test -- --test-threads 1` shows the same five failures on this branch as on clean master against Firebird 6 (`boolean` ×2, `execute_procedure`, `select_readcommited_with_nowait`, `server_engine` — all pre-existing FB6 incompatibilities, unrelated to this change), with my three tests added to the passing set (85 → 88 passed).
- `cargo fmt --all -- --check` passes; `cargo build --examples` clean.

## Possible follow-ups (not in this PR to keep it reviewable)

The same `NativeServiceManager` primitive can carry the rest of the service family — trace sessions (`isc_action_svc_trace_start/stop`), nbackup, database properties (sweep interval, shutdown), user management, and validation/sweep — each is just another SPB layout over `start` + `drain_output`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
