### PR TITLE
enable TCP_NODELAY on socket to speed up pure rust client

### DIFF
--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -323,6 +323,11 @@ impl FirebirdWireConnection {
         charset: Charset,
     ) -> Result<Self, FbError> {
         let socket = TcpStream::connect((host, port))?;
+        // The wire protocol is request/response with small writes, so Nagle has
+        // nothing to coalesce and every statement waits out a delayed ACK
+        // (~40ms). Measured against Firebird 2.5: SELECT 1 FROM RDB$DATABASE
+        // 44ms -> 0.2ms, a 1000-row select 107ms -> 5.7ms.
+        let _ = socket.set_nodelay(true);
 
         // System username
         let username =


### PR DESCRIPTION
This is an optimization for the pure rust client i found with some help of claude.

In my use case it shortened many requests by an oder of magnitude or more just because the socket does not wait for a delayed ACK.

## Measurements
| statement | before | after |
|---|---|---|
| `SELECT 1 FROM RDB$DATABASE` | 44 ms | 0.17 ms |
| column metadata query (`RDB$RELATION_FIELDS` join) | 86 ms | 1.8 ms |
| indexed select returning no rows | 84 ms | 2.1 ms |
| 1000-row indexed select | 107 ms | 5.7 ms |

