### PR TITLE
Implement firebird events in the pure rust client

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -9,47 +9,52 @@
 use rsfbclient::{FbError, Queryable, RemoteEventsManager};
 
 fn main() -> Result<(), FbError> {
-    #[cfg(not(feature = "pure_rust"))] // No support for events with pure rust driver
-    {
-        #[cfg(feature = "linking")]
-        let mut conn = rsfbclient::builder_native()
-            .with_dyn_link()
-            .with_remote()
-            .host("localhost")
-            .db_name("examples.fdb")
-            .user("SYSDBA")
-            .pass("masterkey")
-            .connect()?;
+    #[cfg(feature = "linking")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_link()
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
 
-        #[cfg(feature = "dynamic_loading")]
-        let mut conn = rsfbclient::builder_native()
-            .with_dyn_load("./fbclient.lib")
-            .with_remote()
-            .host("localhost")
-            .db_name("examples.fdb")
-            .user("SYSDBA")
-            .pass("masterkey")
-            .connect()?;
+    #[cfg(feature = "dynamic_loading")]
+    let mut conn = rsfbclient::builder_native()
+        .with_dyn_load("./fbclient.lib")
+        .with_remote()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
 
-        let wt = conn.listen_event("ping".to_string(), move |c| {
-            println!("Pong! Some rows here:");
+    #[cfg(feature = "pure_rust")]
+    let mut conn = rsfbclient::builder_pure_rust()
+        .host("localhost")
+        .db_name("examples.fdb")
+        .user("SYSDBA")
+        .pass("masterkey")
+        .connect()?;
 
-            let rows: Vec<(String, String)> = c.query(
-                "select mon$attachment_name, mon$user from mon$attachments",
-                (),
-            )?;
+    let wt = conn.listen_event("ping".to_string(), move |c| {
+        println!("Pong! Some rows here:");
 
-            for row in rows {
-                println!("Attachment {}, user {}", row.0, row.1);
-            }
+        let rows: Vec<(String, String)> = c.query(
+            "select mon$attachment_name, mon$user from mon$attachments",
+            (),
+        )?;
 
-            return Ok(true);
-        })?;
+        for row in rows {
+            println!("Attachment {}, user {}", row.0, row.1);
+        }
 
-        println!("Try ping here with \"POST_EVENT 'ping'\"");
+        return Ok(true);
+    })?;
 
-        wt.join().unwrap()?;
-    }
+    println!("Try ping here with \"POST_EVENT 'ping'\"");
+
+    wt.join().unwrap()?;
 
     Ok(())
 }

--- a/rsfbclient-rust/src/arc4.rs
+++ b/rsfbclient-rust/src/arc4.rs
@@ -1,6 +1,9 @@
 //! Arc4 stream cipher implementation for the firebird wire encryption (Wire Protocol 13)
 
-use std::io::{Read, Write};
+use std::{
+    io::{Read, Write},
+    net::{SocketAddr, TcpStream},
+};
 
 #[derive(Clone)]
 pub struct Arc4 {
@@ -62,6 +65,13 @@ impl<S> Arc4Stream<S> {
             enc_buf: vec![0; buf_len].into_boxed_slice(),
             stream,
         }
+    }
+}
+
+impl Arc4Stream<TcpStream> {
+    /// Address of the server the wrapped stream is connected to
+    pub fn peer_addr(&self) -> std::io::Result<SocketAddr> {
+        self.stream.peer_addr()
     }
 }
 

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -5,13 +5,14 @@ use std::{
     collections::VecDeque,
     env,
     io::{Read, Write},
-    net::TcpStream,
+    net::{SocketAddr, TcpStream},
 };
 
 use crate::{
     arc4::*,
     blr,
     consts::{AuthPluginType, ProtocolVersion, WireOp},
+    events::*,
     srp::*,
     util::*,
     wire::*,
@@ -88,6 +89,14 @@ pub struct FirebirdWireConnection {
     pub(crate) auth_plugin: Option<AuthPlugin>,
     /// Key for the srp auth
     pub(crate) srp_key: [u8; 32],
+
+    /// Auxiliary connection the server pushes the event notifications on.
+    /// Opened on the first wait, and reused afterwards: firebird keeps a single
+    /// auxiliary port per attachment
+    event_channel: Option<EventChannel>,
+
+    /// Id to use for the next event registration
+    next_event_id: u32,
 }
 
 /// Data to keep track about a prepared statement
@@ -313,6 +322,19 @@ impl FirebirdClientSqlOps for RustFbClient {
     }
 }
 
+impl FirebirdClientDbEvents for RustFbClient {
+    fn wait_for_event(
+        &mut self,
+        db_handle: &mut Self::DbHandle,
+        name: String,
+    ) -> Result<(), FbError> {
+        self.conn
+            .as_mut()
+            .map(|conn| conn.wait_for_event(db_handle, &name))
+            .unwrap_or_else(err_client_not_connected)
+    }
+}
+
 fn err_client_not_connected<T>() -> Result<T, FbError> {
     Err("Client not connected to the server, call `attach_database` to connect".into())
 }
@@ -439,6 +461,8 @@ impl FirebirdWireConnection {
                 auth_plugin
             },
             srp_key,
+            event_channel: None,
+            next_event_id: 1,
         })
     }
 
@@ -502,6 +526,9 @@ impl FirebirdWireConnection {
 
     /// Disconnect from the database
     pub fn detach_database(&mut self, db_handle: &mut DbHandle) -> Result<(), FbError> {
+        // The server drops the auxiliary port along with the attachment
+        self.close_event_channel();
+
         self.socket.write_all(&detach(db_handle.0))?;
         self.socket.flush()?;
 
@@ -512,12 +539,141 @@ impl FirebirdWireConnection {
 
     /// Drop the database
     pub fn drop_database(&mut self, db_handle: &mut DbHandle) -> Result<(), FbError> {
+        // The server drops the auxiliary port along with the attachment
+        self.close_event_channel();
+
         self.socket.write_all(&drop_database(db_handle.0))?;
         self.socket.flush()?;
 
         self.read_response()?;
 
         Ok(())
+    }
+
+    /// Wait until `name` is posted on the database.
+    ///
+    /// Blocks the connection: the notification arrives on the auxiliary
+    /// channel, but registering the interest and acknowledging it both happen
+    /// on this connection.
+    pub fn wait_for_event(&mut self, db_handle: &mut DbHandle, name: &str) -> Result<(), FbError> {
+        let name = normalize_event_name(name)?;
+
+        self.open_event_channel(db_handle)?;
+
+        // Firebird considers an interest satisfied as soon as the counter it
+        // holds for the event has reached the counter of the registration, so
+        // registering with a counter of zero always fires straight away. That
+        // first notification carries the current counter and is a
+        // synchronization, not an event. The native client has to do the very
+        // same thing, hence its two `isc_wait_for_event` calls.
+        let event_id = self.new_event_id();
+        let counters = self.que_events(db_handle, name, 0, event_id)?;
+        let posted = event_count(&counters, name)?;
+
+        // Now that the current counter is known, register again: this time the
+        // server only answers once the event is really posted
+        let event_id = self.new_event_id();
+        self.que_events(db_handle, name, posted, event_id)?;
+
+        Ok(())
+    }
+
+    /// Allocate the id of a new event registration.
+    ///
+    /// Every registration gets its own id, so the notification of a previous
+    /// one can never be taken for the one being waited on. Zero is skipped:
+    /// firebird uses it to mark a registration as already handled.
+    fn new_event_id(&mut self) -> u32 {
+        let event_id = self.next_event_id;
+
+        self.next_event_id = self.next_event_id.wrapping_add(1).max(1);
+
+        event_id
+    }
+
+    /// Register an interest in `name` and block until the server notifies it.
+    ///
+    /// Returns the occurrence counters of the notification.
+    fn que_events(
+        &mut self,
+        db_handle: &mut DbHandle,
+        name: &str,
+        count: u32,
+        event_id: u32,
+    ) -> Result<Vec<(String, u32)>, FbError> {
+        // Encoded with the charset of the connection, like every other string
+        // this connection sends
+        let epb = event_block(&self.charset, [(name, count)])?;
+
+        self.socket
+            .write_all(&que_events(db_handle.0, &epb, event_id))?;
+        self.socket.flush()?;
+
+        // The registration is acknowledged here, the notification itself comes
+        // later on the auxiliary channel
+        self.read_response()?;
+
+        let channel = match self.event_channel.as_mut() {
+            Some(channel) => channel,
+            None => return Err(FbError::from("The event channel was closed")),
+        };
+
+        match channel.recv_event(event_id) {
+            Ok(counters) => Ok(counters),
+
+            Err(err) => {
+                // The notification will never arrive, so release the
+                // registration the server is still holding. Best effort: the
+                // whole connection may be gone.
+                self.event_channel = None;
+                self.cancel_events(db_handle, event_id).ok();
+
+                Err(err)
+            }
+        }
+    }
+
+    /// Cancel a pending event registration
+    fn cancel_events(&mut self, db_handle: &mut DbHandle, event_id: u32) -> Result<(), FbError> {
+        self.socket
+            .write_all(&cancel_events(db_handle.0, event_id))?;
+        self.socket.flush()?;
+
+        self.read_response()?;
+
+        Ok(())
+    }
+
+    /// Open the auxiliary connection the event notifications are pushed on, if
+    /// it is not already open for this database handle
+    fn open_event_channel(&mut self, db_handle: &mut DbHandle) -> Result<(), FbError> {
+        if matches!(&self.event_channel, Some(channel) if channel.db_handle() == db_handle.0) {
+            return Ok(());
+        }
+        self.event_channel = None;
+
+        self.socket.write_all(&connect_request(db_handle.0))?;
+        self.socket.flush()?;
+
+        let resp = self.read_response()?;
+        let port = parse_aux_port(&resp.data)?;
+
+        // The server is listening by the time it answered, so connect now: it
+        // gives up on the auxiliary port after `ConnectionTimeout` seconds
+        let peer = self.socket.peer_addr()?;
+        self.event_channel = Some(EventChannel::open(
+            db_handle.0,
+            self.charset.clone(),
+            peer,
+            port,
+        )?);
+
+        Ok(())
+    }
+
+    /// Close the auxiliary event connection, if any
+    fn close_event_channel(&mut self) {
+        self.event_channel = None;
     }
 
     /// Start a new transaction, with the specified transaction parameter buffer
@@ -1245,6 +1401,16 @@ enum FbStream {
 
     /// Arc4 ecrypted stream
     Arc4(Arc4Stream<TcpStream>),
+}
+
+impl FbStream {
+    /// Address of the server this stream is connected to
+    fn peer_addr(&self) -> std::io::Result<SocketAddr> {
+        match self {
+            FbStream::Plain(s) => s.peer_addr(),
+            FbStream::Arc4(s) => s.peer_addr(),
+        }
+    }
 }
 
 impl Read for FbStream {

--- a/rsfbclient-rust/src/consts.rs
+++ b/rsfbclient-rust/src/consts.rs
@@ -166,6 +166,10 @@ pub enum Cnct {
     ClientCrypt = 11,
 }
 
+/// Connection type of a `WireOp::ConnectRequest`: an auxiliary port used to
+/// deliver the asynchronous event notifications
+pub const P_REQ_ASYNC: u32 = 1;
+
 #[derive(Debug, Clone, Copy)]
 pub enum AuthPluginType {
     Srp256,

--- a/rsfbclient-rust/src/events.rs
+++ b/rsfbclient-rust/src/events.rs
@@ -1,0 +1,926 @@
+//! Firebird remote events
+//!
+//! A firebird server never pushes an event notification on the connection that
+//! registered it. It asks the client to open a second, "auxiliary" connection
+//! and delivers the notifications there, so listening for an event needs three
+//! wire operations:
+//!
+//! * `op_connect_request`, once per attachment, on the main connection: the
+//!   server answers with the address it listens on for the auxiliary channel;
+//! * `op_que_events`, on the main connection, to register the interest. It is
+//!   acknowledged by a plain `op_response`;
+//! * `op_event`, pushed by the server on the auxiliary channel, carrying the
+//!   updated occurrence counters.
+//!
+//! A registration is one shot: the server drops it as soon as the notification
+//! was delivered, so waiting again means registering again.
+
+use bytes::{Buf, BytesMut};
+use std::{
+    borrow::Cow,
+    io::Read,
+    net::{Shutdown, SocketAddr, TcpStream},
+    time::Duration,
+};
+
+use crate::{
+    consts::WireOp,
+    wire::{parse_event_notification, EventNotification},
+};
+use rsfbclient_core::{Charset, FbError};
+
+/// Version tag of an event parameter block (`EPB_version1`)
+const EPB_VERSION1: u8 = 1;
+
+/// Maximum length, in bytes, of an encoded firebird event name: the event
+/// parameter block stores the length of a name in a single unsigned byte
+pub const MAX_EVENT_NAME_LEN: usize = u8::MAX as usize;
+
+/// Maximum size, in bytes, of an event parameter block: firebird refuses to
+/// build a block that does not fit in an unsigned short
+pub const MAX_EVENT_BLOCK_LEN: usize = u16::MAX as usize;
+
+/// How long to wait for the auxiliary connection to be established.
+///
+/// The firebird client itself does a plain blocking `connect()` here, but the
+/// server only listens for a bounded time: `aux_request` binds the auxiliary
+/// port and hands it to `aux_connect`, which `select()`s on it for
+/// `port_connect_timeout` seconds before giving up with
+/// `isc_net_event_connect_timeout`. That value comes from the
+/// `isc_dpb_connect_timeout` dpb item, which this client does not send, so the
+/// server falls back to its `ConnectionTimeout` configuration entry, whose
+/// default is 180 seconds (`src/common/config/config.h`).
+///
+/// Waiting any longer would be pointless, the server has stopped listening;
+/// waiting less could cut short a connection it would still have accepted.
+const AUX_CONNECT_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Normalize an event name.
+///
+/// Firebird strips the trailing blanks of an event name, both when a client
+/// registers and when the server stores it, so we do it too: this keeps the
+/// name we send equal to the name we get back in the notification.
+pub fn normalize_event_name(name: &str) -> Result<&str, FbError> {
+    let name = name.trim_end_matches(' ');
+
+    if name.is_empty() {
+        return Err(FbError::from("A firebird event name cannot be empty"));
+    }
+
+    Ok(name)
+}
+
+/// Encode an event name with the charset of the connection.
+///
+/// Event names travel as raw bytes, and the server compares them byte for byte
+/// against the names of the `POST_EVENT` statements, which reach it in the
+/// connection charset. So a name has to be encoded exactly like the rest of the
+/// statements this connection sends, not forced to utf-8.
+///
+/// The length limit is a limit on those *encoded bytes*, not on rust
+/// characters: the block prefixes the name with a single byte of length.
+fn encode_event_name<'a>(charset: &Charset, name: &'a str) -> Result<Cow<'a, [u8]>, FbError> {
+    let name = normalize_event_name(name)?;
+    let encoded = charset.encode(name)?;
+
+    if encoded.len() > MAX_EVENT_NAME_LEN {
+        return Err(FbError::from(format!(
+            "A firebird event name is limited to {} bytes, but '{}' uses {} once encoded in {}",
+            MAX_EVENT_NAME_LEN,
+            name,
+            encoded.len(),
+            charset.on_firebird
+        )));
+    }
+
+    Ok(encoded)
+}
+
+/// Build the event parameter block registering an interest in `events`, a list
+/// of event names with the occurrence counter already known by the caller.
+///
+/// The server notifies the client as soon as the counter it holds for an event
+/// reaches the counter provided here, so registering with a counter of zero
+/// always fires immediately.
+pub fn event_block<'a, I>(charset: &Charset, events: I) -> Result<Vec<u8>, FbError>
+where
+    I: IntoIterator<Item = (&'a str, u32)>,
+{
+    let mut epb = vec![EPB_VERSION1];
+
+    for (name, count) in events {
+        let name = encode_event_name(charset, name)?;
+
+        epb.push(name.len() as u8);
+        epb.extend_from_slice(&name);
+        // Counters are little endian, whatever the endianness of the rest of
+        // the protocol
+        epb.extend_from_slice(&count.to_le_bytes());
+    }
+
+    if epb.len() > MAX_EVENT_BLOCK_LEN {
+        return Err(FbError::from(format!(
+            "The event parameter block is limited to {} bytes, but the requested events need {}",
+            MAX_EVENT_BLOCK_LEN,
+            epb.len()
+        )));
+    }
+
+    Ok(epb)
+}
+
+/// Parse an event parameter block, returning the occurrence counter of every
+/// event name it holds.
+///
+/// The names are decoded with the charset of the connection, the one they were
+/// registered with.
+pub fn parse_event_block(charset: &Charset, epb: &[u8]) -> Result<Vec<(String, u32)>, FbError> {
+    let (version, mut rest) = epb
+        .split_first()
+        .ok_or_else(|| FbError::from("Empty event parameter block"))?;
+
+    if *version != EPB_VERSION1 {
+        return Err(FbError::from(format!(
+            "Unsupported event parameter block version: {}",
+            version
+        )));
+    }
+
+    let mut events = Vec::new();
+
+    while let Some((len, tail)) = rest.split_first() {
+        let len = *len as usize;
+
+        if tail.len() < len + 4 {
+            return Err(FbError::from("Truncated event parameter block"));
+        }
+
+        let (name, tail) = tail.split_at(len);
+        let name = charset.decode(name)?;
+
+        let (count, tail) = tail.split_at(4);
+        let count = u32::from_le_bytes([count[0], count[1], count[2], count[3]]);
+
+        events.push((name, count));
+        rest = tail;
+    }
+
+    Ok(events)
+}
+
+/// Occurrence counter of `name` in a parsed event parameter block
+pub fn event_count(events: &[(String, u32)], name: &str) -> Result<u32, FbError> {
+    events
+        .iter()
+        .find(|(event, _)| event == name)
+        .map(|(_, count)| *count)
+        .ok_or_else(|| {
+            FbError::from(format!(
+                "The server notification does not hold the '{}' event",
+                name
+            ))
+        })
+}
+
+/// Open the tcp connection of the auxiliary channel.
+///
+/// Only the connect is bounded by `timeout`; the reads that follow block until
+/// an event arrives.
+fn connect_aux(addr: SocketAddr, timeout: Duration) -> Result<TcpStream, FbError> {
+    let socket = TcpStream::connect_timeout(&addr, timeout)?;
+
+    set_keep_alive(&socket);
+
+    Ok(socket)
+}
+
+/// Turn `SO_KEEPALIVE` on, like `setKeepAlive` does in firebird's `inet.cpp`.
+///
+/// Only that option is set: the idle delay, the probe interval and the probe
+/// count are left to the system, exactly as the firebird client leaves them.
+///
+/// The standard library does not expose the option, so this goes straight to
+/// the socket api the process is already linked against rather than pulling a
+/// crate in. Failures are ignored on purpose: `aux_connect` ignores them too,
+/// keep alive is a nicety and must never stop the events from working.
+///
+/// Firebird sets the option before connecting; setting it right after makes no
+/// practical difference, as the probes only start once the connection has been
+/// idle for a while.
+#[cfg(unix)]
+fn set_keep_alive(socket: &TcpStream) {
+    use std::os::{
+        fd::AsRawFd,
+        raw::{c_int, c_void},
+    };
+
+    extern "C" {
+        fn setsockopt(
+            socket: c_int,
+            level: c_int,
+            name: c_int,
+            value: *const c_void,
+            option_len: u32,
+        ) -> c_int;
+    }
+
+    let (level, name) = keep_alive_option();
+    let enable: c_int = 1;
+
+    // SAFETY: `enable` outlives the call, and `option_len` describes it exactly
+    unsafe {
+        setsockopt(
+            socket.as_raw_fd(),
+            level,
+            name,
+            &enable as *const c_int as *const c_void,
+            std::mem::size_of::<c_int>() as u32,
+        );
+    }
+}
+
+#[cfg(windows)]
+fn set_keep_alive(socket: &TcpStream) {
+    use std::os::{
+        raw::{c_char, c_int},
+        windows::io::AsRawSocket,
+    };
+
+    #[link(name = "ws2_32")]
+    extern "system" {
+        fn setsockopt(
+            socket: usize,
+            level: c_int,
+            name: c_int,
+            value: *const c_char,
+            option_len: c_int,
+        ) -> c_int;
+    }
+
+    let (level, name) = keep_alive_option();
+    let enable: c_int = 1;
+
+    // SAFETY: `enable` outlives the call, and `option_len` describes it exactly
+    unsafe {
+        setsockopt(
+            socket.as_raw_socket() as usize,
+            level,
+            name,
+            &enable as *const c_int as *const c_char,
+            std::mem::size_of::<c_int>() as c_int,
+        );
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn set_keep_alive(_socket: &TcpStream) {}
+
+/// `SOL_SOCKET` and `SO_KEEPALIVE`, from `<sys/socket.h>`.
+///
+/// These are abi constants, they depend on the platform and not on the version
+/// of its libc. Linux takes them from `asm-generic/socket.h`, except on the few
+/// architectures that kept the historical numbering, which is also the one
+/// windows and every other unix use.
+#[cfg(any(unix, windows))]
+fn keep_alive_option() -> (std::os::raw::c_int, std::os::raw::c_int) {
+    if cfg!(all(
+        any(target_os = "linux", target_os = "android"),
+        not(any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6",
+            target_arch = "sparc",
+            target_arch = "sparc64"
+        ))
+    )) {
+        (1, 9)
+    } else {
+        (0xffff, 0x0008)
+    }
+}
+
+/// The auxiliary connection a firebird server pushes the `op_event`
+/// notifications on
+pub struct EventChannel {
+    /// Handle of the database the channel was opened for
+    db_handle: u32,
+
+    /// Charset of the connection, the one the event names were registered with
+    charset: Charset,
+
+    /// Socket the server pushes the notifications on. Unlike the main
+    /// connection this one is never encrypted nor compressed: firebird builds
+    /// the auxiliary port without carrying over the wire crypt plugin.
+    socket: TcpStream,
+
+    /// Data read from the socket but not consumed yet. Kept between reads so a
+    /// short read never desyncs the packet framing.
+    buff: BytesMut,
+}
+
+impl EventChannel {
+    /// Open the auxiliary connection.
+    ///
+    /// `main_peer` is the address of the main connection and `port` the one the
+    /// server reported: see [`crate::wire::parse_aux_port`] about why the
+    /// address reported by the server is not used.
+    pub fn open(
+        db_handle: u32,
+        charset: Charset,
+        main_peer: SocketAddr,
+        port: u16,
+    ) -> Result<Self, FbError> {
+        let mut addr = main_peer;
+        addr.set_port(port);
+
+        Ok(Self {
+            db_handle,
+            charset,
+            socket: connect_aux(addr, AUX_CONNECT_TIMEOUT)?,
+            buff: BytesMut::with_capacity(256),
+        })
+    }
+
+    /// Handle of the database the channel was opened for
+    pub fn db_handle(&self) -> u32 {
+        self.db_handle
+    }
+
+    /// Block until the server notifies the registration `event_id`, returning
+    /// the occurrence counters it carries.
+    ///
+    /// Notifications of another registration are skipped: cancelling a
+    /// registration races with its delivery, so a stale notification may still
+    /// show up on the channel.
+    pub fn recv_event(&mut self, event_id: u32) -> Result<Vec<(String, u32)>, FbError> {
+        loop {
+            let notification = self.recv_notification()?;
+
+            if notification.event_id == event_id {
+                return parse_event_block(&self.charset, &notification.epb);
+            }
+        }
+    }
+
+    /// Read the next notification, skipping the keep alive packets
+    fn recv_notification(&mut self) -> Result<EventNotification, FbError> {
+        loop {
+            self.fill(4)?;
+            let op_code = self.peek_u32(0);
+
+            if op_code == WireOp::Dummy as u32 {
+                // Keep alive packet, it has no body
+                self.buff.advance(4);
+                continue;
+            }
+
+            if op_code == WireOp::Exit as u32 || op_code == WireOp::Disconnect as u32 {
+                return Err(FbError::from(
+                    "The server closed the event channel while waiting for an event",
+                ));
+            }
+
+            if op_code != WireOp::Event as u32 {
+                return Err(FbError::from(format!(
+                    "Unexpected operation {} on the event channel",
+                    op_code
+                )));
+            }
+
+            // The op code, the database handle, and the length of the event
+            // parameter block, which is what the length of the packet hangs on
+            self.fill(12)?;
+            let epb_len = self.peek_u32(8) as usize;
+
+            // Do not let a corrupt length drive the buffer: firebird never
+            // builds a block bigger than this
+            if epb_len > MAX_EVENT_BLOCK_LEN {
+                return Err(FbError::from(format!(
+                    "The server announced an event parameter block of {} bytes, over the {} bytes limit",
+                    epb_len, MAX_EVENT_BLOCK_LEN
+                )));
+            }
+
+            // The parameter block is padded to a 4 bytes boundary and followed
+            // by the ast routine address, its argument and the registration id
+            let len = 12 + epb_len.next_multiple_of(4) + 12;
+
+            self.fill(len)?;
+            let mut packet = self.buff.split_to(len).freeze();
+
+            return parse_event_notification(&mut packet);
+        }
+    }
+
+    /// Read the big endian u32 buffered at `offset`, without consuming it
+    fn peek_u32(&self, offset: usize) -> u32 {
+        u32::from_be_bytes([
+            self.buff[offset],
+            self.buff[offset + 1],
+            self.buff[offset + 2],
+            self.buff[offset + 3],
+        ])
+    }
+
+    /// Read from the socket until `len` bytes are buffered
+    fn fill(&mut self, len: usize) -> Result<(), FbError> {
+        let mut chunk = [0; 512];
+
+        while self.buff.len() < len {
+            let read = self.socket.read(&mut chunk)?;
+
+            if read == 0 {
+                return Err(FbError::from(
+                    "The event channel was closed while waiting for an event",
+                ));
+            }
+
+            self.buff.extend_from_slice(&chunk[..read]);
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for EventChannel {
+    fn drop(&mut self) {
+        // Let the server know the auxiliary port is gone instead of leaving it
+        // waiting on a half open socket
+        let _ = self.socket.shutdown(Shutdown::Both);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::{cancel_events, connect_request, parse_aux_port, que_events};
+    use bytes::{BufMut, Bytes};
+    use rsfbclient_core::charset::{ASCII, ISO_8859_1, UTF_8, WIN_1252};
+    use std::{io::Write, net::TcpListener, thread, time::Instant};
+
+    /// Read `SO_KEEPALIVE` back from the socket, so the tests check the option
+    /// really landed and not just that the setter was called. It also proves
+    /// the constants of [`keep_alive_option`] are the right ones on whatever
+    /// platform the tests are running on.
+    #[cfg(unix)]
+    fn keep_alive_enabled(socket: &TcpStream) -> bool {
+        use std::os::{
+            fd::AsRawFd,
+            raw::{c_int, c_void},
+        };
+
+        extern "C" {
+            fn getsockopt(
+                socket: c_int,
+                level: c_int,
+                name: c_int,
+                value: *mut c_void,
+                option_len: *mut u32,
+            ) -> c_int;
+        }
+
+        let (level, name) = keep_alive_option();
+        let mut enabled: c_int = 0;
+        let mut len = std::mem::size_of::<c_int>() as u32;
+
+        // SAFETY: `enabled` and `len` outlive the call, and `len` describes
+        // `enabled` exactly
+        let res = unsafe {
+            getsockopt(
+                socket.as_raw_fd(),
+                level,
+                name,
+                &mut enabled as *mut c_int as *mut c_void,
+                &mut len,
+            )
+        };
+
+        assert_eq!(res, 0, "getsockopt(SO_KEEPALIVE) failed");
+
+        enabled != 0
+    }
+
+    #[cfg(windows)]
+    fn keep_alive_enabled(socket: &TcpStream) -> bool {
+        use std::os::{
+            raw::{c_char, c_int},
+            windows::io::AsRawSocket,
+        };
+
+        #[link(name = "ws2_32")]
+        extern "system" {
+            fn getsockopt(
+                socket: usize,
+                level: c_int,
+                name: c_int,
+                value: *mut c_char,
+                option_len: *mut c_int,
+            ) -> c_int;
+        }
+
+        let (level, name) = keep_alive_option();
+        let mut enabled: c_int = 0;
+        let mut len = std::mem::size_of::<c_int>() as c_int;
+
+        // SAFETY: `enabled` and `len` outlive the call, and `len` describes
+        // `enabled` exactly
+        let res = unsafe {
+            getsockopt(
+                socket.as_raw_socket() as usize,
+                level,
+                name,
+                &mut enabled as *mut c_int as *mut c_char,
+                &mut len,
+            )
+        };
+
+        assert_eq!(res, 0, "getsockopt(SO_KEEPALIVE) failed");
+
+        enabled != 0
+    }
+
+    /// Build the `op_event` packet a server would push for `events`
+    fn event_packet(event_id: u32, events: &[(&str, u32)]) -> Bytes {
+        let epb = event_block(&UTF_8, events.iter().copied()).unwrap();
+
+        let mut packet = BytesMut::new();
+        packet.put_u32(WireOp::Event as u32);
+        packet.put_u32(1); // Database handle
+        packet.put_u32(epb.len() as u32);
+        packet.put_slice(&epb);
+        packet.put_slice(&vec![0; epb.len().next_multiple_of(4) - epb.len()]); // Padding
+        packet.put_u32(0); // Ast routine address
+        packet.put_u32(0); // Ast routine argument
+        packet.put_u32(event_id);
+
+        packet.freeze()
+    }
+
+    #[test]
+    fn event_block_single_name() {
+        let epb = event_block(&UTF_8, [("evento", 0)]).unwrap();
+
+        assert_eq!(
+            epb,
+            vec![
+                1, // EPB_version1
+                6, // Name length
+                b'e', b'v', b'e', b'n', b't', b'o', //
+                0, 0, 0, 0, // Counter, little endian
+            ]
+        );
+    }
+
+    #[test]
+    fn event_block_counter_is_little_endian() {
+        let epb = event_block(&UTF_8, [("a", 0x0102_0304)]).unwrap();
+
+        assert_eq!(epb, vec![1, 1, b'a', 0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn event_block_multiple_names() {
+        let epb = event_block(&UTF_8, [("ab", 1), ("c", 2)]).unwrap();
+
+        assert_eq!(epb, vec![1, 2, b'a', b'b', 1, 0, 0, 0, 1, b'c', 2, 0, 0, 0]);
+    }
+
+    #[test]
+    fn event_block_strips_trailing_blanks() {
+        // Firebird strips them on both ends, so the name we send has to match
+        // the name the server sends back
+        assert_eq!(
+            event_block(&UTF_8, [("ab  ", 0)]).unwrap(),
+            event_block(&UTF_8, [("ab", 0)]).unwrap()
+        );
+    }
+
+    #[test]
+    fn event_name_limits_are_counted_in_encoded_bytes() {
+        let ascii = "a".repeat(MAX_EVENT_NAME_LEN);
+        assert!(encode_event_name(&UTF_8, &ascii).is_ok());
+
+        let too_long = "a".repeat(MAX_EVENT_NAME_LEN + 1);
+        assert!(encode_event_name(&UTF_8, &too_long).is_err());
+
+        // The very same name is 256 bytes in utf-8 and 128 in latin 1, so the
+        // limit has to be checked after encoding and not on the rust string:
+        // rejected on one connection, accepted on the other
+        let accented = "é".repeat(128);
+        assert_eq!(accented.chars().count(), 128);
+
+        assert_eq!(accented.len(), 256);
+        assert!(encode_event_name(&UTF_8, &accented).is_err());
+
+        assert_eq!(
+            encode_event_name(&ISO_8859_1, &accented).unwrap().len(),
+            128
+        );
+    }
+
+    #[test]
+    fn event_name_cannot_be_empty() {
+        assert!(normalize_event_name("").is_err());
+        // A name of blanks is empty once the trailing blanks are stripped
+        assert!(normalize_event_name("   ").is_err());
+
+        assert!(event_block(&UTF_8, [("", 0)]).is_err());
+        assert!(event_block(&ISO_8859_1, [("   ", 0)]).is_err());
+    }
+
+    #[test]
+    fn event_name_is_encoded_with_the_connection_charset() {
+        // 'é' is one byte in latin 1 and two in utf-8. Sending the utf-8 bytes
+        // on a latin 1 connection would not match the name the server stored
+        // from `POST_EVENT`, which arrived in the connection charset.
+        assert_eq!(
+            event_block(&ISO_8859_1, [("é", 0)]).unwrap(),
+            vec![1, 1, 0xe9, 0, 0, 0, 0]
+        );
+
+        assert_eq!(
+            event_block(&UTF_8, [("é", 0)]).unwrap(),
+            vec![1, 2, 0xc3, 0xa9, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn event_name_in_windows_1252() {
+        // '€' has no latin 1 encoding, but windows-1252 maps it to 0x80
+        assert_eq!(
+            event_block(&WIN_1252, [("caf\u{e9}\u{20ac}", 0)]).unwrap(),
+            vec![1, 5, b'c', b'a', b'f', 0xe9, 0x80, 0, 0, 0, 0]
+        );
+
+        assert!(event_block(&ISO_8859_1, [("\u{20ac}", 0)]).is_err());
+    }
+
+    #[test]
+    fn event_name_that_the_charset_cannot_represent_is_rejected() {
+        let err = event_block(&ASCII, [("é", 0)]).unwrap_err();
+        assert!(
+            format!("{}", err).contains("ascii"),
+            "unexpected error: {}",
+            err
+        );
+
+        // And it is an error, not a silent replacement
+        assert!(event_block(&ISO_8859_1, [("日本", 0)]).is_err());
+    }
+
+    #[test]
+    fn event_names_roundtrip_through_a_non_utf8_charset() {
+        let name = "caf\u{e9}";
+
+        let epb = event_block(&WIN_1252, [(name, 7)]).unwrap();
+        let events = parse_event_block(&WIN_1252, &epb).unwrap();
+
+        // The decoded name has to compare equal to the one that was registered,
+        // otherwise `event_count` could never find its counter
+        assert_eq!(events, vec![(name.to_string(), 7)]);
+        assert_eq!(event_count(&events, name).unwrap(), 7);
+    }
+
+    #[test]
+    fn parse_event_block_rejects_bytes_the_charset_cannot_decode() {
+        // 0xff is never a valid utf-8 byte
+        assert!(parse_event_block(&UTF_8, &[1, 1, 0xff, 0, 0, 0, 0]).is_err());
+
+        // Anything above 0x7f is out of ascii
+        assert!(parse_event_block(&ASCII, &[1, 1, 0xe9, 0, 0, 0, 0]).is_err());
+
+        // The very same byte decodes fine in latin 1, so this is a charset
+        // mismatch and not a malformed block
+        assert_eq!(
+            parse_event_block(&ISO_8859_1, &[1, 1, 0xe9, 0, 0, 0, 0]).unwrap(),
+            vec![("é".to_string(), 0)]
+        );
+    }
+
+    #[test]
+    fn event_block_size_is_limited() {
+        let name = "a".repeat(MAX_EVENT_NAME_LEN);
+        let events = (0..300).map(|_| (name.as_str(), 0)).collect::<Vec<_>>();
+
+        // 300 * (1 + 255 + 4) + 1 is way past the unsigned short firebird uses
+        assert!(event_block(&UTF_8, events).is_err());
+    }
+
+    #[test]
+    fn parse_event_block_roundtrip() {
+        let epb = event_block(&UTF_8, [("evento", 3), ("outro", 0)]).unwrap();
+
+        assert_eq!(
+            parse_event_block(&UTF_8, &epb).unwrap(),
+            vec![("evento".to_string(), 3), ("outro".to_string(), 0)]
+        );
+    }
+
+    #[test]
+    fn parse_event_block_rejects_invalid_input() {
+        assert!(parse_event_block(&UTF_8, &[]).is_err());
+        // Unknown version
+        assert!(parse_event_block(&UTF_8, &[2, 1, b'a', 0, 0, 0, 0]).is_err());
+        // Name shorter than announced
+        assert!(parse_event_block(&UTF_8, &[1, 6, b'a', 0, 0, 0, 0]).is_err());
+        // Missing counter
+        assert!(parse_event_block(&UTF_8, &[1, 1, b'a', 0, 0]).is_err());
+    }
+
+    #[test]
+    fn event_count_of_a_missing_name_is_an_error() {
+        let events = vec![("a".to_string(), 7)];
+
+        assert_eq!(event_count(&events, "a").unwrap(), 7);
+        assert!(event_count(&events, "b").is_err());
+    }
+
+    #[test]
+    fn connect_request_layout() {
+        assert_eq!(
+            connect_request(0x0a0b_0c0d).as_ref(),
+            [
+                0, 0, 0, 53, // op_connect_request
+                0, 0, 0, 1, // P_REQ_async
+                0x0a, 0x0b, 0x0c, 0x0d, // Database handle
+                0, 0, 0, 0, // Partner identification
+            ]
+        );
+    }
+
+    #[test]
+    fn que_events_layout() {
+        // A 7 bytes block, so the padding to 4 bytes is exercised
+        let epb = event_block(&UTF_8, [("a", 0)]).unwrap();
+        assert_eq!(epb.len(), 7);
+
+        assert_eq!(
+            que_events(1, &epb, 42).as_ref(),
+            [
+                0, 0, 0, 48, // op_que_events
+                0, 0, 0, 1, // Database handle
+                0, 0, 0, 7, // Event parameter block length
+                1, 1, b'a', 0, 0, 0, 0, // The block itself
+                0, // Padding to a 4 bytes boundary
+                0, 0, 0, 0, // Ast routine address
+                0, 0, 0, 0, // Ast routine argument
+                0, 0, 0, 42, // Event id
+            ]
+        );
+    }
+
+    #[test]
+    fn cancel_events_layout() {
+        assert_eq!(
+            cancel_events(1, 42).as_ref(),
+            [
+                0, 0, 0, 49, // op_cancel_events
+                0, 0, 0, 1, // Database handle
+                0, 0, 0, 42, // Event id
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_event_notification_reads_the_counters() {
+        let mut packet = event_packet(42, &[("evento", 5)]);
+
+        let notification = parse_event_notification(&mut packet).unwrap();
+        assert_eq!(notification.event_id, 42);
+        assert_eq!(
+            parse_event_block(&UTF_8, &notification.epb).unwrap(),
+            vec![("evento".to_string(), 5)]
+        );
+        // The whole packet was consumed, padding included
+        assert!(packet.is_empty());
+    }
+
+    #[test]
+    fn parse_event_notification_of_an_unpadded_block() {
+        // A 4 bytes aligned block adds no padding at all
+        let epb = event_block(&UTF_8, [("ab", 0)]).unwrap();
+        assert_eq!(epb.len(), 8);
+
+        let mut packet = event_packet(1, &[("ab", 0)]);
+        let notification = parse_event_notification(&mut packet).unwrap();
+
+        assert_eq!(
+            parse_event_block(&UTF_8, &notification.epb).unwrap(),
+            vec![("ab".to_string(), 0)]
+        );
+        assert!(packet.is_empty());
+    }
+
+    #[test]
+    fn parse_event_notification_rejects_another_operation() {
+        let mut packet = Bytes::from_static(&[0, 0, 0, 9]);
+
+        assert!(parse_event_notification(&mut packet).is_err());
+    }
+
+    #[test]
+    fn aux_port_is_read_in_network_byte_order() {
+        // sockaddr_in of 192.168.1.10:32771, as a little endian host writes it
+        let sockaddr = [
+            2, 0, // sin_family, host byte order
+            0x80, 0x03, // sin_port, network byte order
+            192, 168, 1, 10, // sin_addr
+            0, 0, 0, 0, 0, 0, 0, 0, // sin_zero
+        ];
+
+        assert_eq!(parse_aux_port(&sockaddr).unwrap(), 0x8003);
+    }
+
+    #[test]
+    fn aux_port_ignores_the_address_family_layout() {
+        // A macOS server writes sa_len then sa_family, but the port stays at
+        // the same offset, in the same byte order
+        let macos = [16, 2, 0x0b, 0xea, 127, 0, 0, 1];
+        let posix = [2, 0, 0x0b, 0xea, 127, 0, 0, 1];
+
+        assert_eq!(parse_aux_port(&macos).unwrap(), 3050);
+        assert_eq!(parse_aux_port(&posix).unwrap(), 3050);
+    }
+
+    #[test]
+    fn aux_port_rejects_invalid_data() {
+        assert!(parse_aux_port(&[]).is_err());
+        assert!(parse_aux_port(&[2, 0, 1]).is_err());
+        // A port of zero means the server failed to listen
+        assert!(parse_aux_port(&[2, 0, 0, 0, 127, 0, 0, 1]).is_err());
+    }
+
+    /// The connect timeout is not a value we get to pick: it is the window the
+    /// server keeps the auxiliary port open, see `AUX_CONNECT_TIMEOUT`
+    #[test]
+    fn aux_connect_timeout_is_the_firebird_connection_timeout() {
+        assert_eq!(AUX_CONNECT_TIMEOUT, Duration::from_secs(180));
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn aux_socket_enables_keep_alive() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Off by default, so the assert below cannot pass by accident
+        let plain = TcpStream::connect(addr).unwrap();
+        assert!(!keep_alive_enabled(&plain));
+
+        let stream = connect_aux(addr, AUX_CONNECT_TIMEOUT).unwrap();
+        assert!(keep_alive_enabled(&stream));
+    }
+
+    /// `recv_event` blocks on the socket until an event arrives: a non blocking
+    /// mode left over from `connect_timeout` would turn every quiet moment
+    /// into an error
+    #[test]
+    fn aux_socket_is_blocking() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut stream = connect_aux(addr, AUX_CONNECT_TIMEOUT).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+
+        let reader = thread::spawn(move || {
+            let mut byte = [0; 1];
+            stream.read_exact(&mut byte).map(|_| byte[0])
+        });
+
+        // A non blocking socket would have given up with WouldBlock by now
+        thread::sleep(Duration::from_millis(200));
+        assert!(!reader.is_finished());
+
+        server.write_all(&[42]).unwrap();
+        assert_eq!(reader.join().unwrap().unwrap(), 42);
+    }
+
+    /// Bounding the connect must not slow down or break a connect that works
+    #[test]
+    fn aux_connect_succeeds_within_the_timeout() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let start = Instant::now();
+        let stream = connect_aux(addr, Duration::from_secs(30)).unwrap();
+
+        assert_eq!(stream.peer_addr().unwrap(), addr);
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    /// A refused connection has to surface right away instead of waiting for
+    /// the whole timeout
+    #[test]
+    fn aux_connect_reports_a_refused_connection() {
+        // Bind then drop, so the port is almost certainly free and refusing
+        let addr = {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            listener.local_addr().unwrap()
+        };
+
+        let start = Instant::now();
+        assert!(connect_aux(addr, AUX_CONNECT_TIMEOUT).is_err());
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+}

--- a/rsfbclient-rust/src/lib.rs
+++ b/rsfbclient-rust/src/lib.rs
@@ -4,6 +4,7 @@ mod arc4;
 mod blr;
 mod client;
 mod consts;
+mod events;
 mod srp;
 mod util;
 mod wire;

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, convert::TryFrom, str};
 
 use crate::{
     client::{BlobId, FirebirdWireConnection},
-    consts::{gds_to_msg, AuthPluginType, Cnct, ProtocolVersion, WireOp},
+    consts::{gds_to_msg, AuthPluginType, Cnct, ProtocolVersion, WireOp, P_REQ_ASYNC},
     srp::*,
     util::*,
     xsqlda::{XSqlVar, XSQLDA_DESCRIBE_VARS},
@@ -535,6 +535,99 @@ pub fn fetch(stmt_handle: u32, blr: &[u8], count: u32) -> Bytes {
     req.put_u32(count); // Message count: request a batch of rows in a single round-trip
 
     req.freeze()
+}
+
+/// Auxiliary channel request.
+///
+/// Firebird does not push the event notifications on the connection that
+/// registered them: it asks the client to open a second, "async" connection
+/// and answers this request with the address it listens on for it.
+pub fn connect_request(db_handle: u32) -> Bytes {
+    let mut req = BytesMut::with_capacity(16);
+
+    req.put_u32(WireOp::ConnectRequest as u32);
+    req.put_u32(P_REQ_ASYNC); // Connection type
+    req.put_u32(db_handle); // Related object
+    req.put_u32(0); // Partner identification
+
+    req.freeze()
+}
+
+/// Event notification request
+pub fn que_events(db_handle: u32, epb: &[u8], event_id: u32) -> Bytes {
+    let mut req = BytesMut::with_capacity(24 + epb.len());
+
+    req.put_u32(WireOp::QueEvents as u32);
+    req.put_u32(db_handle);
+    req.put_wire_bytes(epb); // Event parameter block
+    req.put_u32(0); // Ast routine address, unused by the remote protocol
+    req.put_u32(0); // Ast routine argument, unused by the remote protocol
+    req.put_u32(event_id);
+
+    req.freeze()
+}
+
+/// Cancel an event notification request
+pub fn cancel_events(db_handle: u32, event_id: u32) -> Bytes {
+    let mut req = BytesMut::with_capacity(12);
+
+    req.put_u32(WireOp::CancelEvents as u32);
+    req.put_u32(db_handle);
+    req.put_u32(event_id);
+
+    req.freeze()
+}
+
+#[derive(Debug)]
+/// `WireOp::Event` notification, pushed by the server on the auxiliary channel
+pub struct EventNotification {
+    /// Id of the `WireOp::QueEvents` registration this notification answers
+    pub event_id: u32,
+    /// Event parameter block holding the updated occurrence counters
+    pub epb: Bytes,
+}
+
+/// Parse an event notification (`WireOp::Event`), op code included
+pub fn parse_event_notification(resp: &mut Bytes) -> Result<EventNotification, FbError> {
+    let op_code = resp.get_u32()?;
+
+    if op_code != WireOp::Event as u32 {
+        return err_conn_rejected(op_code);
+    }
+
+    resp.get_u32()?; // Database handle
+    let epb = resp.get_wire_bytes()?;
+    resp.get_u32()?; // Ast routine address, always zero
+    resp.get_u32()?; // Ast routine argument, always zero
+    let event_id = resp.get_u32()?;
+
+    Ok(EventNotification { event_id, epb })
+}
+
+/// Extract the port of the auxiliary channel from the `WireOp::ConnectRequest`
+/// response data, which holds a raw `sockaddr` of the server.
+///
+/// Only the port is used: the address the server reports is the one it sees
+/// locally, which is wrong as soon as it sits behind a NAT, so the reference
+/// client reuses the address of the main connection instead. This is what
+/// `aux_connect` does in the firebird sources. The port lives at offset 2 in
+/// network byte order for both `sockaddr_in` and `sockaddr_in6`, whatever the
+/// sockaddr layout of the server.
+pub fn parse_aux_port(data: &[u8]) -> Result<u16, FbError> {
+    if data.len() < 4 {
+        return Err(FbError::from(
+            "Invalid auxiliary channel address returned by the server",
+        ));
+    }
+
+    let port = u16::from_be_bytes([data[2], data[3]]);
+    if port == 0 {
+        return Err(FbError::from(
+            "The server did not return a port for the auxiliary event channel",
+        ));
+    }
+
+    Ok(port)
 }
 
 /// Create blob request

--- a/src/connection/simple.rs
+++ b/src/connection/simple.rs
@@ -185,9 +185,7 @@ impl SimpleConnection {
             #[cfg(feature = "dynamic_loading")]
             TypeConnectionContainer::NativeDynLoad(c) => c.wait_for_event(name),
             #[cfg(feature = "pure_rust")]
-            TypeConnectionContainer::PureRust(c) => {
-                Err(FbError::from("Events only works with the native client"))
-            }
+            TypeConnectionContainer::PureRust(c) => c.wait_for_event(name),
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -75,8 +75,8 @@ mk_tests_default! {
 
     #[test]
     #[ignore]
-    #[cfg(all(not(feature = "pure_rust"), not(feature = "embedded_tests")))]
-    fn remote_events_native() -> Result<(), FbError> {
+    #[cfg(not(feature = "embedded_tests"))]
+    fn remote_events() -> Result<(), FbError> {
         let conn1 = cbuilder().connect()?;
         let mut conn2 = cbuilder().connect()?;
 
@@ -113,9 +113,17 @@ mk_tests_default! {
         Ok(())
     }
 
+    // `RemoteEventsManager` carries a client type that `SimpleConnection` does
+    // not constrain, so this call only compiles when a single client
+    // implementation is built in. Skipped otherwise, as it was before the pure
+    // rust client learned about events.
     #[test]
     #[ignore]
-    #[cfg(all(not(feature = "pure_rust"), not(feature = "embedded_tests")))]
+    #[cfg(all(
+        not(feature = "embedded_tests"),
+        not(all(feature = "native_client", feature = "pure_rust")),
+        not(all(feature = "linking", feature = "dynamic_loading"))
+    ))]
     fn remote_events_simple_conn() -> Result<(), FbError> {
         let conn1: SimpleConnection = cbuilder().connect()?.into();
         let mut conn2: SimpleConnection = cbuilder().connect()?.into();
@@ -147,7 +155,7 @@ mk_tests_default! {
 
     #[test]
     #[ignore]
-    #[cfg(all(not(feature = "pure_rust"), not(feature = "embedded_tests")))]
+    #[cfg(not(feature = "embedded_tests"))]
     fn wait_for_event() -> Result<(), FbError> {
 
         let mut conn1 = cbuilder().connect()?;
@@ -165,6 +173,79 @@ mk_tests_default! {
 
         thread::sleep(Duration::from_secs(10));
         assert!(wait.is_finished());
+
+        Ok(())
+    }
+
+    /// A registration is one shot, so waiting twice on the same connection has
+    /// to register twice. The second wait also reuses the auxiliary channel
+    /// opened by the first one.
+    #[test]
+    #[ignore]
+    #[cfg(not(feature = "embedded_tests"))]
+    fn wait_for_event_twice() -> Result<(), FbError> {
+
+        let mut listener = cbuilder().connect()?;
+        let mut poster = cbuilder().connect()?;
+
+        let waits = thread::spawn(move || -> Result<(), FbError> {
+            listener.wait_for_event("evento4".to_string())?;
+            listener.wait_for_event("evento4".to_string())?;
+
+            Ok(())
+        });
+
+        thread::sleep(Duration::from_secs(2));
+        poster.execute("execute block as begin POST_EVENT 'evento4'; end", ())?;
+
+        thread::sleep(Duration::from_secs(2));
+        assert!(!waits.is_finished(), "the second wait returned without an event");
+
+        poster.execute("execute block as begin POST_EVENT 'evento4'; end", ())?;
+
+        thread::sleep(Duration::from_secs(2));
+        assert!(waits.is_finished(), "the second event was not delivered");
+        waits.join().expect("the listener thread panicked")?;
+
+        Ok(())
+    }
+
+    /// The server matches event names on their raw bytes, so a name has to be
+    /// encoded with the charset of the connection, the one `POST_EVENT` reaches
+    /// it with. Posting the same name from a utf-8 connection does not wake a
+    /// listener registered from a latin 1 one.
+    ///
+    /// Only the pure rust client does this: the native one always sends the
+    /// utf-8 bytes of the rust string, so the test is skipped when it is built
+    /// in.
+    #[test]
+    #[ignore]
+    #[cfg(all(
+        feature = "pure_rust",
+        not(feature = "native_client"),
+        not(feature = "embedded_tests")
+    ))]
+    fn wait_for_event_with_a_non_utf8_charset() -> Result<(), FbError> {
+
+        let name = "ev\u{e9}nement";
+
+        let mut builder = cbuilder();
+        builder.charset(charset::ISO_8859_1);
+
+        let mut listener = builder.connect()?;
+        let mut poster = builder.connect()?;
+
+        let waits = thread::spawn(move || listener.wait_for_event(name.to_string()));
+
+        thread::sleep(Duration::from_secs(2));
+        poster.execute(
+            &format!("execute block as begin POST_EVENT '{}'; end", name),
+            (),
+        )?;
+
+        thread::sleep(Duration::from_secs(3));
+        assert!(waits.is_finished(), "the latin 1 event was not delivered");
+        waits.join().expect("the listener thread panicked")?;
 
         Ok(())
     }


### PR DESCRIPTION
Firebird events in the pure rust client
wait_for_event and listen_event only worked with rsfbclient-native. With pure_rust they returned "Events only works with the native client".

This implements FirebirdClientDbEvents for RustFbClient: op_connect_request to open the auxiliary connection firebird delivers notifications on, then op_que_events / op_event / op_cancel_events. Event names are encoded with the connection charset, since the server matches them byte for byte against POST_EVENT.

No API change — the existing events API just starts working. rsfbclient-core and rsfbclient-native are untouched, and there is no new dependency.

Tests
29 unit tests covering the packet layouts, the event parameter block and the charset handling, none of which need a database. The existing integration tests now also run for pure_rust, plus two new ones.

Known limits
One event name per wait, and no occurrence count: the trait carries neither. 
The wait blocks the connection and can't be interrupted, same as the native client.