### PR TITLE
fix(pure_rust): restore Firebird 2.5 support broken by #177

### DIFF
--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -336,9 +336,9 @@ fn dpb(data: &[DpbData<'_>]) -> Bytes {
 
     let mut dpb = BytesMut::with_capacity(64);
 
-    let v2 = max_len < 255;
+    let v2 = max_len > 255;
 
-    dpb.put_u8(if v2 { 2 } else { 1 }); //Version
+    dpb.put_u8(if v2 { ibase::isc_dpb_version2 } else { ibase::isc_dpb_version1 } as u8); //Version
 
     for d in data {
         dpb.put_u8(d.tag);


### PR DESCRIPTION
Since #177 (c5ab7c3), `attach` fails on Firebird 2.5 with:

    Invalid clumplet buffer structure: buffer end before end of clumplet - clumplet too long

The DPB builder selected the wide clumplet format (`isc_dpb_version2`, 4-byte
lengths) whenever every parameter was *shorter* than 255 bytes — the condition
was inverted, and that format only exists since Firebird 3.0. Firebird 2.5 reads
the DPB with single-byte lengths, so its parser desynchronised immediately. The
other branch was broken too: it emitted version 1 with a length truncated to
`u8`.

Fixed by selecting the wide format only when a parameter actually exceeds 255
bytes. Every value the driver sends is well under that, so both 2.5 and 3+ now
receive a version 1 DPB, as before #177.

Tested against Firebird 2.5 with the `pure_rust` backend.