### PR TITLE
fix(pure_rust): prefer Srp256 in the connect request

### DIFF
--- a/rsfbclient-rust/src/consts.rs
+++ b/rsfbclient-rust/src/consts.rs
@@ -185,9 +185,13 @@ impl AuthPluginType {
         }
     }
 
-    /// List with the plugins
+    /// List with the plugins, in order of preference. Must lead with the same
+    /// plugin as `Cnct::PluginName` in the connect request: the client only sends
+    /// auth data for that one, so a server that picks another plugin has to ask
+    /// for the data in an extra op_cont_auth round trip -- which Firebird 5
+    /// rejects when it answered op_accept_data (WireCrypt = Disabled).
     pub fn plugin_list() -> String {
-        [AuthPluginType::Srp.name(), AuthPluginType::Srp256.name()].join(",")
+        [AuthPluginType::Srp256.name(), AuthPluginType::Srp.name()].join(",")
     }
 
     pub fn parse(name: &[u8]) -> Result<Self, rsfbclient_core::FbError> {

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -53,8 +53,9 @@ pub fn connect(db_name: &str, user: &str, username: &str, hostname: &str, srp_ke
         uid.put_u8(user.len() as u8);
         uid.put(user.as_bytes());
 
-        // Request SRP by default
-        let plugin = AuthPluginType::Srp.name();
+        // Request the strongest plugin we implement; the server falls back to the
+        // next one in the plugin list below if it does not support it
+        let plugin = AuthPluginType::Srp256.name();
 
         uid.put_u8(Cnct::PluginName as u8);
         uid.put_u8(plugin.len() as u8);


### PR DESCRIPTION
With `WireCrypt = Disabled` the pure-rust client still fails to attach ("unavailable database"), even after the `op_accept_data` support added in bf5e5db: the connect request names Srp (SHA-1) as its plugin and lists it first, but Firebird 5 defaults to `AuthServer = Srp256, Srp, Legacy_Auth` and picks Srp256. The client only sends specific auth data (the SRP public key) for the plugin it names, so the server ends up choosing a plugin the client sent no data for. Under `op_cond_accept` that costs an extra `op_cont_auth` round trip; under `op_accept_data` — which is what a `WireCrypt = Disabled` server answers — there is no way back and the attach is rejected.

This names Srp256 in the connect request and lists it first, matching fbclient (which has led with Srp256 since Firebird 4) and the server default. Srp stays in the list as the fallback for servers without Srp256.

### How it was tested

The standard test suite (`cargo test --no-default-features --features pure_rust`) against `jacobalberty/firebird:v5` with `WireCrypt = Disabled` appended to `firebird.conf`:

- before this change: every connection fails, 84 tests red
- after: 84 pass

Also run against the same server with the default WireCrypt (`op_cond_accept` path) and against `jacobalberty/firebird:v3`, which has no Srp256 and so exercises the fallback. In both, the same 6 tests fail before and after the change (roles, `execute_block`, `execute_procedure`, `insert_returning`, `simple::execute`) — they need a server setup the local container doesn't have and are unrelated to this patch.

I don't see a good way to cover this in CI as it stands: it needs a server with a non-default `WireCrypt`/`AuthServer`. Happy to add a job for it if you want one.

