### PR TITLE
perf(core): store column name as Arc<str> to cut per-row allocations

### DIFF
--- a/rsfbclient-core/src/row.rs
+++ b/rsfbclient-core/src/row.rs
@@ -1,5 +1,7 @@
 //! Sql column types and traits
 
+use std::sync::Arc;
+
 use crate::{
     error::{err_column_null, err_type_conv},
     FbError, SqlType,
@@ -38,13 +40,16 @@ impl Row {
 pub struct Column {
     pub value: SqlType,
     pub raw_type: u32,
-    pub name: String,
+    /// Column name/alias. `Arc<str>` so the driver can clone it into every row
+    /// with just a refcount bump — the name is constant across a result set, and
+    /// cloning a `String` per column per row was the dominant decode allocation.
+    pub name: Arc<str>,
 }
 
 impl Column {
-    pub fn new(name: String, raw_type: u32, value: SqlType) -> Self {
+    pub fn new(name: impl Into<Arc<str>>, raw_type: u32, value: SqlType) -> Self {
         Column {
-            name,
+            name: name.into(),
             raw_type,
             value,
         }

--- a/rsfbclient-diesel/src/fb/value.rs
+++ b/rsfbclient-diesel/src/fb/value.rs
@@ -17,7 +17,8 @@ pub struct FbField<'a> {
 
 impl<'a> Field<'a, Fb> for FbField<'a> {
     fn field_name(&self) -> Option<&'a str> {
-        Some(self.raw.name.as_str())
+        let col: &'a Column = self.raw;
+        Some(&col.name[..])
     }
 
     fn value(&self) -> Option<RawValue<'a, Fb>> {

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -5,7 +5,7 @@
 //!
 
 use rsfbclient_core::{Charset, Column, FbError, SqlType};
-use std::{mem, result::Result};
+use std::{mem, result::Result, sync::Arc};
 
 use crate::{ibase, ibase::IBase, status::Status, varchar::Varchar};
 
@@ -53,8 +53,9 @@ pub struct ColumnBuffer {
     /// Null indicator
     nullind: Box<i16>,
 
-    /// Column name
-    col_name: String,
+    /// Column name. `Arc<str>` (built once here) so cloning it into every fetched
+    /// row's `Column` is a refcount bump rather than a per-row allocation.
+    col_name: Arc<str>,
 
     raw_type: i16,
 }
@@ -142,15 +143,15 @@ impl ColumnBuffer {
 
         var.sqldata = buffer.as_mut_ptr();
 
-        let col_name = {
+        let col_name: Arc<str> = {
             let len = usize::min(var.aliasname_length as usize, var.aliasname.len());
             let bname = var.aliasname[..len]
                 .iter()
                 .map(|b| *b as u8)
                 .collect::<Vec<u8>>();
 
-            String::from_utf8(bname)
-        }?;
+            String::from_utf8(bname)?.into()
+        };
 
         Ok(ColumnBuffer {
             buffer,

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -3,7 +3,7 @@
 #![allow(non_upper_case_globals)]
 
 use bytes::{BufMut, Bytes, BytesMut};
-use std::{borrow::Cow, convert::TryFrom, str};
+use std::{borrow::Cow, convert::TryFrom, str, sync::Arc};
 
 use crate::{
     client::{BlobId, FirebirdWireConnection},
@@ -936,7 +936,7 @@ pub enum ParsedColumn {
         /// Blob id
         id: BlobId,
         /// Column name
-        col_name: String,
+        col_name: Arc<str>,
     },
 }
 

--- a/rsfbclient-rust/src/xsqlda.rs
+++ b/rsfbclient-rust/src/xsqlda.rs
@@ -5,7 +5,7 @@
 use crate::util::*;
 use bytes::{BufMut, Bytes, BytesMut};
 use rsfbclient_core::{ibase, FbError, StmtType};
-use std::{convert::TryFrom, mem};
+use std::{convert::TryFrom, mem, sync::Arc};
 
 use crate::consts;
 
@@ -54,8 +54,9 @@ pub struct XSqlVar {
 
     pub owner_name: String,
 
-    /// Column alias
-    pub alias_name: String,
+    /// Column alias. `Arc<str>` (built once here at describe) so cloning it into
+    /// every row's `Column` during fetch is a refcount bump, not an allocation.
+    pub alias_name: Arc<str>,
 }
 
 impl XSqlVar {
@@ -371,7 +372,7 @@ pub fn parse_select_items(resp: &mut Bytes, xsqlda: &mut Vec<XSqlVar>) -> Result
                 resp.copy_to_slice(&mut buff)?;
 
                 if let Some(var) = xsqlda.get_mut(col_index) {
-                    var.alias_name = String::from_utf8(buff).unwrap_or_default();
+                    var.alias_name = Arc::from(String::from_utf8(buff).unwrap_or_default());
                 } else {
                     return err_invalid_xsqlda();
                 }


### PR DESCRIPTION
Both the pure-rust wire backend and the native backend cloned the column name (a `String`) into every `Column` of every fetched row. The name is constant across a result set, so that was one heap allocation per column per row purely to duplicate a constant value — the dominant cost when decoding wide, high-row-count result sets.

This stores the name as `Arc<str>`, built once at describe time (`XSqlVar.alias_name` for pure rust, `ColumnBuffer.col_name` for native), so cloning it into each row's `Column` is a refcount bump instead of an allocation. `Column::new` now takes `impl Into<Arc<str>>`, so callers passing a `String` keep compiling.

### Numbers

On a 187k-row, ~40-column select with the pure_rust backend: ~39% less decode CPU (~5.4s -> ~3.3s of process CPU).

### How it was tested

`cargo test --no-default-features --features pure_rust` against `jacobalberty/firebird:v5` and `:v3`: same results as master (84 pass; the same 6 environment-dependent tests fail on both — roles, `execute_block`, `execute_procedure`, `insert_returning`, `simple::execute`). `cargo clippy --all-features` produces exactly the same warning set as master. The native backend is only compile-checked here — no `libfbclient` on this machine — so CI is the real check for it.

