### PR TITLE
perf(pure_rust): decode blob-free rows straight into Vec<Column>

### DIFF
--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -34,16 +34,36 @@ fn fetch_batch_size() -> u32 {
         .unwrap_or(200)
 }
 
-/// Result of parsing ONE op_fetch_response. Blob columns are still unresolved:
-/// fetching them costs extra round-trips that must not be interleaved with the
-/// responses of the running batch (see `fetch_batch`).
-enum FetchOne {
+/// Size of the scratch buffer for a single socket read. Batch fetch pulls many
+/// rows per op_fetch, so a bigger read cuts read syscalls and, more importantly,
+/// keeps rows from being split mid-response and re-parsed on the
+/// incomplete-response retry path of `read_with` (wasted CPU that scales with
+/// the column count).
+const READ_BUFFER_LEN: usize = 64 * 1024;
+
+/// Result of parsing ONE op_fetch_response. `T` is the decoded row: statements
+/// with blob columns use `Vec<ParsedColumn>`, since fetching a blob costs extra
+/// round-trips that must not be interleaved with the responses of the running
+/// batch (see `fetch_batch`); blob-free statements decode straight into
+/// `Vec<Column>`.
+enum FetchOne<T> {
     /// A row (status=0, messages=1).
-    Row(Vec<ParsedColumn>),
+    Row(T),
     /// End of THIS batch (status=0, messages=0): the server ended the op_fetch
     /// without exhausting the cursor. Re-issuing op_fetch fetches the rest.
     BatchEnd,
     /// End of cursor (status=100). Nothing more to read.
+    End,
+}
+
+/// What one op_fetch_response is, decided from its framing alone (op code,
+/// status and message count) before any column is decoded.
+enum Framed {
+    /// A row is present; `resp` is left at the start of the response body.
+    Row,
+    /// End of this batch: the response was consumed, no row.
+    BatchEnd,
+    /// End of cursor: the response was consumed, nothing more to read.
     End,
 }
 
@@ -117,6 +137,11 @@ pub struct StmtHandleData {
     prefetched: VecDeque<Vec<Column>>,
     /// Cursor exhausted on the server (do not request more batches).
     cursor_eof: bool,
+    /// Any output column is a blob. Blobs need a deferred round-trip to fetch, so
+    /// they go through the two-phase `ParsedColumn` path. When false (the common
+    /// case) fetch decodes rows straight into `Vec<Column>`, skipping the second
+    /// buffer and the per-column move loop.
+    has_blob: bool,
 }
 
 impl RustFbClient {
@@ -377,8 +402,7 @@ impl FirebirdWireConnection {
         socket.write_all(&req)?;
         socket.flush()?;
 
-        // May be a bit too much
-        let mut buff = vec![0; BUFFER_LENGTH as usize * 2].into_boxed_slice();
+        let mut buff = vec![0; READ_BUFFER_LEN].into_boxed_slice();
         let mut pending = Bytes::new();
 
         let ConnectionResponse {
@@ -863,6 +887,9 @@ impl FirebirdWireConnection {
             var.coerce()?;
         }
         let blr = xsqlda_to_blr(&xsqlda)?;
+        let has_blob = xsqlda
+            .iter()
+            .any(|var| var.sqltype as u32 & !1 == ibase::SQL_BLOB);
 
         Ok((
             stmt_type,
@@ -873,6 +900,7 @@ impl FirebirdWireConnection {
                 param_count,
                 prefetched: VecDeque::new(),
                 cursor_eof: false,
+                has_blob,
             },
         ))
     }
@@ -1047,6 +1075,74 @@ impl FirebirdWireConnection {
             .write_all(&fetch(stmt_handle.handle.0, &stmt_handle.blr, count))?;
         self.socket.flush()?;
 
+        if stmt_handle.has_blob {
+            self.read_batch_deferring_blobs(tr_handle, stmt_handle, count)
+        } else {
+            self.read_batch_columns(stmt_handle, count)
+        }
+    }
+
+    /// Reads a batch of a blob-free statement, decoding each row straight into
+    /// `Vec<Column>`: no `ParsedColumn` buffer, no per-column move loop and no
+    /// per-row charset clone (`into_column` is not used, so the charset is only
+    /// borrowed).
+    fn read_batch_columns(
+        &mut self,
+        stmt_handle: &mut StmtHandleData,
+        count: u32,
+    ) -> Result<(), FbError> {
+        let version = self.version;
+        let charset = self.charset.clone();
+        let xsqlda = &stmt_handle.xsqlda;
+
+        let mut rows = Vec::new();
+        let mut cursor_eof = false;
+        let mut got = 0u32;
+
+        loop {
+            let one = read_with(
+                &mut self.socket,
+                &mut self.buff,
+                &mut self.pending,
+                &mut self.lazy_count,
+                |resp, lazy_count| {
+                    parse_one_fetch_response_columns(resp, lazy_count, xsqlda, version, &charset)
+                },
+            )?;
+
+            match one {
+                FetchOne::Row(cols) => {
+                    rows.push(cols);
+                    got += 1;
+                    // Same as in `read_batch_deferring_blobs`: the terminating
+                    // op_fetch_response has to be consumed, so don't stop on
+                    // got >= count.
+                    if got > count {
+                        return Err("server sent more rows than requested in op_fetch".into());
+                    }
+                }
+                FetchOne::BatchEnd => break,
+                FetchOne::End => {
+                    cursor_eof = true;
+                    break;
+                }
+            }
+        }
+
+        stmt_handle.cursor_eof = cursor_eof;
+        stmt_handle.prefetched.extend(rows);
+
+        Ok(())
+    }
+
+    /// Reads a batch of a statement with blob columns: the rows are parsed first
+    /// and the blobs resolved afterwards, once the batch is fully consumed.
+    fn read_batch_deferring_blobs(
+        &mut self,
+        tr_handle: &mut TrHandle,
+        stmt_handle: &mut StmtHandleData,
+        count: u32,
+    ) -> Result<(), FbError> {
         let version = self.version;
         let charset = self.charset.clone();
         let xsqlda = &stmt_handle.xsqlda;
@@ -1284,7 +1380,45 @@ fn parse_one_fetch_response(
     xsqlda: &[XSqlVar],
     version: ProtocolVersion,
     charset: &Charset,
-) -> Result<FetchOne, FbError> {
+) -> Result<FetchOne<Vec<ParsedColumn>>, FbError> {
+    match frame_fetch_response(resp, lazy_count)? {
+        Framed::End => return Ok(FetchOne::End),
+        Framed::BatchEnd => return Ok(FetchOne::BatchEnd),
+        Framed::Row => {}
+    }
+
+    // Delegate to the crate parser (re-reads status+messages+data).
+    match parse_fetch_response(resp, xsqlda, version, charset)? {
+        Some(parsed) => Ok(FetchOne::Row(parsed)),
+        None => Ok(FetchOne::End),
+    }
+}
+
+/// Same as [`parse_one_fetch_response`], for a statement with no blob columns:
+/// the row is decoded straight into `Vec<Column>`.
+fn parse_one_fetch_response_columns(
+    resp: &mut Bytes,
+    lazy_count: &mut u32,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<FetchOne<Vec<Column>>, FbError> {
+    match frame_fetch_response(resp, lazy_count)? {
+        Framed::End => return Ok(FetchOne::End),
+        Framed::BatchEnd => return Ok(FetchOne::BatchEnd),
+        Framed::Row => {}
+    }
+
+    match parse_fetch_response_columns(resp, xsqlda, version, charset)? {
+        Some(cols) => Ok(FetchOne::Row(cols)),
+        None => Ok(FetchOne::End),
+    }
+}
+
+/// Frames ONE op_fetch_response: consumes the response when it carries no row,
+/// and leaves `resp` at the start of the body when it does, so the caller can
+/// decode the row the way it needs.
+fn frame_fetch_response(resp: &mut Bytes, lazy_count: &mut u32) -> Result<Framed, FbError> {
     let op_code = skip_lazy_responses(resp, lazy_count)?;
 
     if op_code == WireOp::Response as u32 {
@@ -1313,20 +1447,16 @@ fn parse_one_fetch_response(
         // leave four bytes in the stream for the next operation to read as its
         // op code (op 0 -> "Connection rejected with code 0").
         resp.advance(8)?;
-        return Ok(FetchOne::End);
+        return Ok(Framed::End);
     }
 
     if messages == 0 {
         // End of this batch with no row.
         resp.advance(8)?;
-        return Ok(FetchOne::BatchEnd);
+        return Ok(Framed::BatchEnd);
     }
 
-    // A row is present. Delegate to the crate parser (re-reads status+messages+data).
-    match parse_fetch_response(resp, xsqlda, version, charset)? {
-        Some(parsed) => Ok(FetchOne::Row(parsed)),
-        None => Ok(FetchOne::End),
-    }
+    Ok(Framed::Row)
 }
 
 /// Read a server response

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -732,6 +732,27 @@ pub fn parse_fetch_response(
     Ok(Some(parse_sql_response(resp, xsqlda, version, charset)?))
 }
 
+/// Like [`parse_fetch_response`] but decodes straight into `Vec<Column>`. Only
+/// valid when the statement has no blob columns (caller checks `has_blob`).
+pub fn parse_fetch_response_columns(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<Option<Vec<Column>>, FbError> {
+    const END_OF_STREAM: u32 = 100;
+
+    let status = resp.get_u32()?;
+
+    if status == END_OF_STREAM {
+        return Ok(None);
+    }
+
+    Ok(Some(parse_sql_response_columns(
+        resp, xsqlda, version, charset,
+    )?))
+}
+
 /// Parse a server sql response (`WireOp::SqlResponse`)
 /// Identical to the FetchResponse, but has no status
 pub fn parse_sql_response(
@@ -740,6 +761,50 @@ pub fn parse_sql_response(
     version: ProtocolVersion,
     charset: &Charset,
 ) -> Result<Vec<ParsedColumn>, FbError> {
+    let mut data = Vec::with_capacity(xsqlda.len());
+    parse_sql_response_each(resp, xsqlda, version, charset, |pc| {
+        data.push(pc);
+        Ok(())
+    })?;
+    Ok(data)
+}
+
+/// Like [`parse_sql_response`] but decodes straight into `Vec<Column>`, skipping
+/// the intermediate `Vec<ParsedColumn>` and the per-column move loop. Only valid
+/// when the statement has no blob columns: a blob here is an error, since
+/// resolving it needs a connection round-trip this function does not have.
+pub fn parse_sql_response_columns(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<Vec<Column>, FbError> {
+    let mut cols = Vec::with_capacity(xsqlda.len());
+    parse_sql_response_each(resp, xsqlda, version, charset, |pc| match pc {
+        ParsedColumn::Complete(c) => {
+            cols.push(c);
+            Ok(())
+        }
+        ParsedColumn::Blob { .. } => {
+            Err("parse_sql_response_columns called on a statement with blob columns".into())
+        }
+    })?;
+    Ok(cols)
+}
+
+/// Shared per-column decoder for a sql/fetch response body (after op_code). Feeds
+/// each decoded column to `sink`. The wire format lives here once; callers decide
+/// whether to collect `ParsedColumn` (blob path) or `Column` directly (fast path).
+fn parse_sql_response_each<F>(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+    mut sink: F,
+) -> Result<(), FbError>
+where
+    F: FnMut(ParsedColumn) -> Result<(), FbError>,
+{
     let has_row = resp.get_u32()? != 0;
     if !has_row {
         return Err("Fetch returned no columns".into());
@@ -776,19 +841,17 @@ pub fn parse_sql_response(
         }
     };
 
-    let mut data = Vec::with_capacity(xsqlda.len());
-
     for (col_index, var) in xsqlda.iter().enumerate() {
         // Remove nullable type indicator
         let sqltype = var.sqltype as u32 & (!1);
 
         if version >= ProtocolVersion::V13 && read_null(resp, col_index)? {
             // There is no data in protocol 13 if null, so just continue
-            data.push(ParsedColumn::Complete(Column::new(
+            sink(ParsedColumn::Complete(Column::new(
                 var.alias_name.clone(),
                 sqltype,
                 SqlType::Null,
-            )));
+            )))?;
             continue;
         }
 
@@ -798,17 +861,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Text(charset.decode(&d[..])?),
-                    )))
+                    )))?
                 }
             }
 
@@ -817,17 +880,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Integer(i),
-                    )))
+                    )))?
                 }
             }
 
@@ -836,17 +899,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Floating(f),
-                    )))
+                    )))?
                 }
             }
 
@@ -858,17 +921,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
-                    )))
+                    )))?
                 }
             }
 
@@ -877,17 +940,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Blob {
+                    sink(ParsedColumn::Blob {
                         binary: var.sqlsubtype == 0,
                         id: BlobId(id),
                         col_name: var.alias_name.clone(),
-                    })
+                    })?
                 }
             }
 
@@ -898,17 +961,17 @@ pub fn parse_sql_response(
                 let null = read_null(resp, col_index)?;
 
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Boolean(b),
-                    )))
+                    )))?
                 }
             }
 
@@ -922,7 +985,7 @@ pub fn parse_sql_response(
         }
     }
 
-    Ok(data)
+    Ok(())
 }
 
 /// Column data parsed from a fetch response


### PR DESCRIPTION
The fetch decode always built a `Vec<ParsedColumn>` and then a second `Vec<Column>`, moving every column across (on a wide, high-row-count select that is ~40-70 moves per row plus a second allocation). `ParsedColumn` only exists so a blob column can defer its round-trip until the batch is fully read; a statement with no blob columns never needs it.

- precompute `has_blob` once at prepare (scan the output xsqlda)
- factor the per-column wire decode into `parse_sql_response_each`, driven by a sink closure. The blob path collects `ParsedColumn` as before; the blob-free path (`parse_sql_response_columns` / `parse_fetch_response_columns`) writes `Column` straight into one `Vec` — no second buffer, no move loop, and no per-row charset clone (`into_column` is not used, so the charset is only borrowed)
- split the `op_fetch_response` framing (`frame_fetch_response`) from the row decode, so both paths share the op_code / lazy / status-peek handling, and make `FetchOne` generic over the decoded row
- grow the socket read buffer from 2 KiB to 64 KiB. Batch fetch pulls many rows per `op_fetch`, so this cuts read syscalls and stops rows from being split mid-response and re-parsed on the incomplete-response retry path of `read_with` (wasted CPU that scaled with the column count)

### Numbers

On a 187k-row, ~58-text-column select: driver CPU per row ~14.6us -> ~9.0us, whole process CPU ~3.3s -> ~2.3s. Output is byte-identical to the previous build, verified with an order-independent content hash of the loaded table.

### How it was tested

`cargo test --no-default-features --features pure_rust` against `jacobalberty/firebird:v5` and `:v3`: same results as master (84 pass; the same 6 environment-dependent tests fail on both). Both paths are already covered by the existing suite — the fast path by every blob-free select, the `ParsedColumn` path by the blob tests in `row.rs` and `params.rs` (including the big-blob ones). `cargo clippy --all-features` produces exactly the same warning set as master.

