### PR TITLE
feat(pure_rust): zero-copy row streaming (RawValue / stream_raw)

### DIFF
--- a/rsfbclient-rust/Cargo.toml
+++ b/rsfbclient-rust/Cargo.toml
@@ -15,6 +15,7 @@ digest = "0.10.3"
 generic-array = "0.14.4"
 hex = "0.4.3"
 lazy_static = "1.4.0"
+chrono = { version = "0.4", default-features = false }
 num-bigint = "0.4.0"
 num_enum = "0.5.7"
 pwhash = "1.0.0"

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -13,6 +13,7 @@ use crate::{
     blr,
     consts::{AuthPluginType, ProtocolVersion, WireOp},
     events::*,
+    raw::RawValue,
     srp::*,
     util::*,
     wire::*,
@@ -366,6 +367,34 @@ impl FirebirdClientDbEvents for RustFbClient {
 
 fn err_client_not_connected<T>() -> Result<T, FbError> {
     Err("Client not connected to the server, call `attach_database` to connect".into())
+}
+
+impl StmtHandleData {
+    /// Whether any output column is a blob. Raw streaming
+    /// ([`RustFbClient::stream_raw`]) requires this to be false.
+    pub fn has_blob(&self) -> bool {
+        self.has_blob
+    }
+}
+
+impl RustFbClient {
+    /// Streaming fetch with no per-row allocation: each row is decoded straight
+    /// into a reusable `Vec<RawValue>` (text borrows the read buffer, so there is
+    /// no `Vec<Column>` and no `String` per row) and handed to `visit`. The
+    /// statement must be blob-free (see [`StmtHandleData::has_blob`]).
+    pub fn stream_raw<V>(
+        &mut self,
+        stmt_handle: &mut StmtHandleData,
+        visit: V,
+    ) -> Result<(), FbError>
+    where
+        V: FnMut(&[RawValue]) -> Result<(), FbError>,
+    {
+        self.conn
+            .as_mut()
+            .map(|conn| conn.stream_raw(stmt_handle, visit))
+            .unwrap_or_else(err_client_not_connected)
+    }
 }
 
 impl FirebirdWireConnection {
@@ -1201,6 +1230,102 @@ impl FirebirdWireConnection {
         Ok(())
     }
 
+    /// Streaming fetch that decodes each row straight into a reusable
+    /// `Vec<RawValue>` (text borrows the read buffer; no `Vec<Column>`, no
+    /// per-text `String`) and hands it to `visit`. Requires a blob-free statement
+    /// and a cursor with no rows buffered by [`Self::fetch`].
+    pub fn stream_raw<V>(
+        &mut self,
+        stmt_handle: &mut StmtHandleData,
+        mut visit: V,
+    ) -> Result<(), FbError>
+    where
+        V: FnMut(&[RawValue]) -> Result<(), FbError>,
+    {
+        if stmt_handle.has_blob {
+            return Err("stream_raw requires a statement with no blob columns".into());
+        }
+        if !stmt_handle.prefetched.is_empty() {
+            return Err("stream_raw cannot resume a cursor with rows buffered by fetch".into());
+        }
+
+        let count = fetch_batch_size();
+        let mut row = Vec::new();
+        let mut empty_batches = 0u32;
+
+        while !stmt_handle.cursor_eof {
+            let delivered = self.fetch_batch_raw(stmt_handle, count, &mut row, &mut visit)?;
+
+            // Same safety net as `fetch`: a well-behaved server never sends empty
+            // batches without exhausting the cursor.
+            if delivered == 0 {
+                empty_batches += 1;
+                if empty_batches > 1000 {
+                    return Err("stream_raw: too many empty batches without end of cursor".into());
+                }
+            } else {
+                empty_batches = 0;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// One op_fetch of up to `count` rows, decoded into `row` and delivered to
+    /// `visit` as they are parsed. Returns how many rows were delivered.
+    fn fetch_batch_raw<V>(
+        &mut self,
+        stmt_handle: &mut StmtHandleData,
+        count: u32,
+        row: &mut Vec<RawValue>,
+        visit: &mut V,
+    ) -> Result<u32, FbError>
+    where
+        V: FnMut(&[RawValue]) -> Result<(), FbError>,
+    {
+        self.socket
+            .write_all(&fetch(stmt_handle.handle.0, &stmt_handle.blr, count))?;
+        self.socket.flush()?;
+
+        let version = self.version;
+        let xsqlda = &stmt_handle.xsqlda;
+        let mut cursor_eof = false;
+        let mut got = 0u32;
+
+        loop {
+            let framed = read_with(
+                &mut self.socket,
+                &mut self.buff,
+                &mut self.pending,
+                &mut self.lazy_count,
+                |resp, lazy_count| {
+                    parse_one_fetch_response_raw(resp, lazy_count, xsqlda, version, row)
+                },
+            )?;
+
+            match framed {
+                // `row` borrows the read buffer, so it has to be consumed before
+                // the next response is read.
+                Framed::Row => {
+                    visit(row)?;
+                    got += 1;
+                    if got > count {
+                        return Err("server sent more rows than requested in op_fetch".into());
+                    }
+                }
+                Framed::BatchEnd => break,
+                Framed::End => {
+                    cursor_eof = true;
+                    break;
+                }
+            }
+        }
+
+        stmt_handle.cursor_eof = cursor_eof;
+
+        Ok(got)
+    }
+
     /// Create a new blob, returning the blob handle and id
     pub fn create_blob(
         &mut self,
@@ -1412,6 +1537,28 @@ fn parse_one_fetch_response_columns(
     match parse_fetch_response_columns(resp, xsqlda, version, charset)? {
         Some(cols) => Ok(FetchOne::Row(cols)),
         None => Ok(FetchOne::End),
+    }
+}
+
+/// Same as [`parse_one_fetch_response`], decoding the row into `out` as
+/// [`RawValue`] instead of building a `Vec<Column>`.
+fn parse_one_fetch_response_raw(
+    resp: &mut Bytes,
+    lazy_count: &mut u32,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    out: &mut Vec<RawValue>,
+) -> Result<Framed, FbError> {
+    match frame_fetch_response(resp, lazy_count)? {
+        Framed::End => Ok(Framed::End),
+        Framed::BatchEnd => Ok(Framed::BatchEnd),
+        Framed::Row => {
+            if parse_fetch_response_raw(resp, xsqlda, version, out)? {
+                Ok(Framed::Row)
+            } else {
+                Ok(Framed::End)
+            }
+        }
     }
 }
 

--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -34,16 +34,36 @@ fn fetch_batch_size() -> u32 {
         .unwrap_or(200)
 }
 
-/// Result of parsing ONE op_fetch_response. Blob columns are still unresolved:
-/// fetching them costs extra round-trips that must not be interleaved with the
-/// responses of the running batch (see `fetch_batch`).
-enum FetchOne {
+/// Size of the scratch buffer for a single socket read. Batch fetch pulls many
+/// rows per op_fetch, so a bigger read cuts read syscalls and, more importantly,
+/// keeps rows from being split mid-response and re-parsed on the
+/// incomplete-response retry path of `read_with` (wasted CPU that scales with
+/// the column count).
+const READ_BUFFER_LEN: usize = 64 * 1024;
+
+/// Result of parsing ONE op_fetch_response. `T` is the decoded row: statements
+/// with blob columns use `Vec<ParsedColumn>`, since fetching a blob costs extra
+/// round-trips that must not be interleaved with the responses of the running
+/// batch (see `fetch_batch`); blob-free statements decode straight into
+/// `Vec<Column>`.
+enum FetchOne<T> {
     /// A row (status=0, messages=1).
-    Row(Vec<ParsedColumn>),
+    Row(T),
     /// End of THIS batch (status=0, messages=0): the server ended the op_fetch
     /// without exhausting the cursor. Re-issuing op_fetch fetches the rest.
     BatchEnd,
     /// End of cursor (status=100). Nothing more to read.
+    End,
+}
+
+/// What one op_fetch_response is, decided from its framing alone (op code,
+/// status and message count) before any column is decoded.
+enum Framed {
+    /// A row is present; `resp` is left at the start of the response body.
+    Row,
+    /// End of this batch: the response was consumed, no row.
+    BatchEnd,
+    /// End of cursor: the response was consumed, nothing more to read.
     End,
 }
 
@@ -117,6 +137,11 @@ pub struct StmtHandleData {
     prefetched: VecDeque<Vec<Column>>,
     /// Cursor exhausted on the server (do not request more batches).
     cursor_eof: bool,
+    /// Any output column is a blob. Blobs need a deferred round-trip to fetch, so
+    /// they go through the two-phase `ParsedColumn` path. When false (the common
+    /// case) fetch decodes rows straight into `Vec<Column>`, skipping the second
+    /// buffer and the per-column move loop.
+    has_blob: bool,
 }
 
 impl RustFbClient {
@@ -377,8 +402,7 @@ impl FirebirdWireConnection {
         socket.write_all(&req)?;
         socket.flush()?;
 
-        // May be a bit too much
-        let mut buff = vec![0; BUFFER_LENGTH as usize * 2].into_boxed_slice();
+        let mut buff = vec![0; READ_BUFFER_LEN].into_boxed_slice();
         let mut pending = Bytes::new();
 
         let ConnectionResponse {
@@ -863,6 +887,9 @@ impl FirebirdWireConnection {
             var.coerce()?;
         }
         let blr = xsqlda_to_blr(&xsqlda)?;
+        let has_blob = xsqlda
+            .iter()
+            .any(|var| var.sqltype as u32 & !1 == ibase::SQL_BLOB);
 
         Ok((
             stmt_type,
@@ -873,6 +900,7 @@ impl FirebirdWireConnection {
                 param_count,
                 prefetched: VecDeque::new(),
                 cursor_eof: false,
+                has_blob,
             },
         ))
     }
@@ -1047,6 +1075,74 @@ impl FirebirdWireConnection {
             .write_all(&fetch(stmt_handle.handle.0, &stmt_handle.blr, count))?;
         self.socket.flush()?;
 
+        if stmt_handle.has_blob {
+            self.read_batch_deferring_blobs(tr_handle, stmt_handle, count)
+        } else {
+            self.read_batch_columns(stmt_handle, count)
+        }
+    }
+
+    /// Reads a batch of a blob-free statement, decoding each row straight into
+    /// `Vec<Column>`: no `ParsedColumn` buffer, no per-column move loop and no
+    /// per-row charset clone (`into_column` is not used, so the charset is only
+    /// borrowed).
+    fn read_batch_columns(
+        &mut self,
+        stmt_handle: &mut StmtHandleData,
+        count: u32,
+    ) -> Result<(), FbError> {
+        let version = self.version;
+        let charset = self.charset.clone();
+        let xsqlda = &stmt_handle.xsqlda;
+
+        let mut rows = Vec::new();
+        let mut cursor_eof = false;
+        let mut got = 0u32;
+
+        loop {
+            let one = read_with(
+                &mut self.socket,
+                &mut self.buff,
+                &mut self.pending,
+                &mut self.lazy_count,
+                |resp, lazy_count| {
+                    parse_one_fetch_response_columns(resp, lazy_count, xsqlda, version, &charset)
+                },
+            )?;
+
+            match one {
+                FetchOne::Row(cols) => {
+                    rows.push(cols);
+                    got += 1;
+                    // Same as in `read_batch_deferring_blobs`: the terminating
+                    // op_fetch_response has to be consumed, so don't stop on
+                    // got >= count.
+                    if got > count {
+                        return Err("server sent more rows than requested in op_fetch".into());
+                    }
+                }
+                FetchOne::BatchEnd => break,
+                FetchOne::End => {
+                    cursor_eof = true;
+                    break;
+                }
+            }
+        }
+
+        stmt_handle.cursor_eof = cursor_eof;
+        stmt_handle.prefetched.extend(rows);
+
+        Ok(())
+    }
+
+    /// Reads a batch of a statement with blob columns: the rows are parsed first
+    /// and the blobs resolved afterwards, once the batch is fully consumed.
+    fn read_batch_deferring_blobs(
+        &mut self,
+        tr_handle: &mut TrHandle,
+        stmt_handle: &mut StmtHandleData,
+        count: u32,
+    ) -> Result<(), FbError> {
         let version = self.version;
         let charset = self.charset.clone();
         let xsqlda = &stmt_handle.xsqlda;
@@ -1284,7 +1380,45 @@ fn parse_one_fetch_response(
     xsqlda: &[XSqlVar],
     version: ProtocolVersion,
     charset: &Charset,
-) -> Result<FetchOne, FbError> {
+) -> Result<FetchOne<Vec<ParsedColumn>>, FbError> {
+    match frame_fetch_response(resp, lazy_count)? {
+        Framed::End => return Ok(FetchOne::End),
+        Framed::BatchEnd => return Ok(FetchOne::BatchEnd),
+        Framed::Row => {}
+    }
+
+    // Delegate to the crate parser (re-reads status+messages+data).
+    match parse_fetch_response(resp, xsqlda, version, charset)? {
+        Some(parsed) => Ok(FetchOne::Row(parsed)),
+        None => Ok(FetchOne::End),
+    }
+}
+
+/// Same as [`parse_one_fetch_response`], for a statement with no blob columns:
+/// the row is decoded straight into `Vec<Column>`.
+fn parse_one_fetch_response_columns(
+    resp: &mut Bytes,
+    lazy_count: &mut u32,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<FetchOne<Vec<Column>>, FbError> {
+    match frame_fetch_response(resp, lazy_count)? {
+        Framed::End => return Ok(FetchOne::End),
+        Framed::BatchEnd => return Ok(FetchOne::BatchEnd),
+        Framed::Row => {}
+    }
+
+    match parse_fetch_response_columns(resp, xsqlda, version, charset)? {
+        Some(cols) => Ok(FetchOne::Row(cols)),
+        None => Ok(FetchOne::End),
+    }
+}
+
+/// Frames ONE op_fetch_response: consumes the response when it carries no row,
+/// and leaves `resp` at the start of the body when it does, so the caller can
+/// decode the row the way it needs.
+fn frame_fetch_response(resp: &mut Bytes, lazy_count: &mut u32) -> Result<Framed, FbError> {
     let op_code = skip_lazy_responses(resp, lazy_count)?;
 
     if op_code == WireOp::Response as u32 {
@@ -1313,20 +1447,16 @@ fn parse_one_fetch_response(
         // leave four bytes in the stream for the next operation to read as its
         // op code (op 0 -> "Connection rejected with code 0").
         resp.advance(8)?;
-        return Ok(FetchOne::End);
+        return Ok(Framed::End);
     }
 
     if messages == 0 {
         // End of this batch with no row.
         resp.advance(8)?;
-        return Ok(FetchOne::BatchEnd);
+        return Ok(Framed::BatchEnd);
     }
 
-    // A row is present. Delegate to the crate parser (re-reads status+messages+data).
-    match parse_fetch_response(resp, xsqlda, version, charset)? {
-        Some(parsed) => Ok(FetchOne::Row(parsed)),
-        None => Ok(FetchOne::End),
-    }
+    Ok(Framed::Row)
 }
 
 /// Read a server response

--- a/rsfbclient-rust/src/lib.rs
+++ b/rsfbclient-rust/src/lib.rs
@@ -5,12 +5,14 @@ mod blr;
 mod client;
 mod consts;
 mod events;
+mod raw;
 mod srp;
 mod util;
 mod wire;
 mod xsqlda;
 
 pub use client::{DbHandle, RustFbClient, RustFbClientAttachmentConfig, StmtHandle, TrHandle};
+pub use raw::RawValue;
 
 #[cfg(feature = "fuzz_testing")]
 pub use self::{blr::*, wire::*, xsqlda::*};

--- a/rsfbclient-rust/src/raw.rs
+++ b/rsfbclient-rust/src/raw.rs
@@ -1,0 +1,36 @@
+//! Zero-copy row streaming for the pure-rust backend.
+//!
+//! [`RawValue`] carries a column value with no owned allocation: text is a
+//! `Bytes` handle onto the wire read buffer (an O(1) refcount clone, no copy and
+//! no `String`), scalars are plain values. Paired with a reusable scratch
+//! `Vec<RawValue>` per fetch, this skips the per-row `Vec<Column>` and the
+//! per-text-column `String` that the `Column` API allocates.
+//!
+//! Blob columns are not supported on this path (they need a deferred round-trip);
+//! callers fall back to the `Column` API when the statement has blobs.
+
+use bytes::Bytes;
+use chrono::NaiveDateTime;
+
+/// A single column value, borrowed from the wire buffer where possible.
+#[derive(Debug, Clone)]
+pub enum RawValue {
+    Null,
+    Integer(i64),
+    Floating(f64),
+    Boolean(bool),
+    Timestamp(NaiveDateTime),
+    /// Raw column bytes straight from the wire buffer, in the connection charset
+    /// (UTF-8 for a UTF8 connection). A refcounted slice: cloning is O(1) and
+    /// there is no `String` allocation nor a copy out of the buffer.
+    Text(Bytes),
+}
+
+impl RawValue {
+    /// Build a `Text` value from a byte slice. Mainly for tests and consumers
+    /// that don't hold a wire `Bytes`; the streaming path passes the wire slice
+    /// directly.
+    pub fn text_bytes(bytes: &[u8]) -> Self {
+        RawValue::Text(Bytes::copy_from_slice(bytes))
+    }
+}

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -732,6 +732,27 @@ pub fn parse_fetch_response(
     Ok(Some(parse_sql_response(resp, xsqlda, version, charset)?))
 }
 
+/// Like [`parse_fetch_response`] but decodes straight into `Vec<Column>`. Only
+/// valid when the statement has no blob columns (caller checks `has_blob`).
+pub fn parse_fetch_response_columns(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<Option<Vec<Column>>, FbError> {
+    const END_OF_STREAM: u32 = 100;
+
+    let status = resp.get_u32()?;
+
+    if status == END_OF_STREAM {
+        return Ok(None);
+    }
+
+    Ok(Some(parse_sql_response_columns(
+        resp, xsqlda, version, charset,
+    )?))
+}
+
 /// Parse a server sql response (`WireOp::SqlResponse`)
 /// Identical to the FetchResponse, but has no status
 pub fn parse_sql_response(
@@ -740,6 +761,50 @@ pub fn parse_sql_response(
     version: ProtocolVersion,
     charset: &Charset,
 ) -> Result<Vec<ParsedColumn>, FbError> {
+    let mut data = Vec::with_capacity(xsqlda.len());
+    parse_sql_response_each(resp, xsqlda, version, charset, |pc| {
+        data.push(pc);
+        Ok(())
+    })?;
+    Ok(data)
+}
+
+/// Like [`parse_sql_response`] but decodes straight into `Vec<Column>`, skipping
+/// the intermediate `Vec<ParsedColumn>` and the per-column move loop. Only valid
+/// when the statement has no blob columns: a blob here is an error, since
+/// resolving it needs a connection round-trip this function does not have.
+pub fn parse_sql_response_columns(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+) -> Result<Vec<Column>, FbError> {
+    let mut cols = Vec::with_capacity(xsqlda.len());
+    parse_sql_response_each(resp, xsqlda, version, charset, |pc| match pc {
+        ParsedColumn::Complete(c) => {
+            cols.push(c);
+            Ok(())
+        }
+        ParsedColumn::Blob { .. } => {
+            Err("parse_sql_response_columns called on a statement with blob columns".into())
+        }
+    })?;
+    Ok(cols)
+}
+
+/// Shared per-column decoder for a sql/fetch response body (after op_code). Feeds
+/// each decoded column to `sink`. The wire format lives here once; callers decide
+/// whether to collect `ParsedColumn` (blob path) or `Column` directly (fast path).
+fn parse_sql_response_each<F>(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    charset: &Charset,
+    mut sink: F,
+) -> Result<(), FbError>
+where
+    F: FnMut(ParsedColumn) -> Result<(), FbError>,
+{
     let has_row = resp.get_u32()? != 0;
     if !has_row {
         return Err("Fetch returned no columns".into());
@@ -776,19 +841,17 @@ pub fn parse_sql_response(
         }
     };
 
-    let mut data = Vec::with_capacity(xsqlda.len());
-
     for (col_index, var) in xsqlda.iter().enumerate() {
         // Remove nullable type indicator
         let sqltype = var.sqltype as u32 & (!1);
 
         if version >= ProtocolVersion::V13 && read_null(resp, col_index)? {
             // There is no data in protocol 13 if null, so just continue
-            data.push(ParsedColumn::Complete(Column::new(
+            sink(ParsedColumn::Complete(Column::new(
                 var.alias_name.clone(),
                 sqltype,
                 SqlType::Null,
-            )));
+            )))?;
             continue;
         }
 
@@ -798,17 +861,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Text(charset.decode(&d[..])?),
-                    )))
+                    )))?
                 }
             }
 
@@ -817,17 +880,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Integer(i),
-                    )))
+                    )))?
                 }
             }
 
@@ -836,17 +899,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Floating(f),
-                    )))
+                    )))?
                 }
             }
 
@@ -858,17 +921,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
-                    )))
+                    )))?
                 }
             }
 
@@ -877,17 +940,17 @@ pub fn parse_sql_response(
 
                 let null = read_null(resp, col_index)?;
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Blob {
+                    sink(ParsedColumn::Blob {
                         binary: var.sqlsubtype == 0,
                         id: BlobId(id),
                         col_name: var.alias_name.clone(),
-                    })
+                    })?
                 }
             }
 
@@ -898,17 +961,17 @@ pub fn parse_sql_response(
                 let null = read_null(resp, col_index)?;
 
                 if null {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Null,
-                    )))
+                    )))?
                 } else {
-                    data.push(ParsedColumn::Complete(Column::new(
+                    sink(ParsedColumn::Complete(Column::new(
                         var.alias_name.clone(),
                         sqltype,
                         SqlType::Boolean(b),
-                    )))
+                    )))?
                 }
             }
 
@@ -922,7 +985,7 @@ pub fn parse_sql_response(
         }
     }
 
-    Ok(data)
+    Ok(())
 }
 
 /// Column data parsed from a fetch response

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -8,6 +8,7 @@ use std::{borrow::Cow, convert::TryFrom, str};
 use crate::{
     client::{BlobId, FirebirdWireConnection},
     consts::{gds_to_msg, AuthPluginType, Cnct, ProtocolVersion, WireOp, P_REQ_ASYNC},
+    raw::RawValue,
     srp::*,
     util::*,
     xsqlda::{XSqlVar, XSQLDA_DESCRIBE_VARS},
@@ -762,10 +763,15 @@ pub fn parse_sql_response(
     charset: &Charset,
 ) -> Result<Vec<ParsedColumn>, FbError> {
     let mut data = Vec::with_capacity(xsqlda.len());
-    parse_sql_response_each(resp, xsqlda, version, charset, |pc| {
-        data.push(pc);
-        Ok(())
-    })?;
+    decode_row(
+        resp,
+        xsqlda,
+        version,
+        &mut ParsedColumnSink {
+            charset,
+            out: &mut data,
+        },
+    )?;
     Ok(data)
 }
 
@@ -780,31 +786,266 @@ pub fn parse_sql_response_columns(
     charset: &Charset,
 ) -> Result<Vec<Column>, FbError> {
     let mut cols = Vec::with_capacity(xsqlda.len());
-    parse_sql_response_each(resp, xsqlda, version, charset, |pc| match pc {
-        ParsedColumn::Complete(c) => {
-            cols.push(c);
-            Ok(())
-        }
-        ParsedColumn::Blob { .. } => {
-            Err("parse_sql_response_columns called on a statement with blob columns".into())
-        }
-    })?;
+    decode_row(
+        resp,
+        xsqlda,
+        version,
+        &mut ColumnSink {
+            charset,
+            out: &mut cols,
+        },
+    )?;
     Ok(cols)
 }
 
-/// Shared per-column decoder for a sql/fetch response body (after op_code). Feeds
-/// each decoded column to `sink`. The wire format lives here once; callers decide
-/// whether to collect `ParsedColumn` (blob path) or `Column` directly (fast path).
-fn parse_sql_response_each<F>(
+/// Like [`parse_fetch_response`] but decodes into `out` as [`RawValue`], with no
+/// charset decode and no per-column allocation: text is a `Bytes` handle onto the
+/// read buffer. `out` is reused across rows, so a whole result set streams with no
+/// per-row allocation. Returns `Ok(false)` at end of cursor. Blob columns are
+/// rejected (the caller checks `has_blob`).
+pub fn parse_fetch_response_raw(
     resp: &mut Bytes,
     xsqlda: &[XSqlVar],
     version: ProtocolVersion,
-    charset: &Charset,
-    mut sink: F,
-) -> Result<(), FbError>
-where
-    F: FnMut(ParsedColumn) -> Result<(), FbError>,
-{
+    out: &mut Vec<RawValue>,
+) -> Result<bool, FbError> {
+    const END_OF_STREAM: u32 = 100;
+
+    let status = resp.get_u32()?;
+
+    if status == END_OF_STREAM {
+        return Ok(false);
+    }
+
+    parse_sql_response_raw(resp, xsqlda, version, out)?;
+
+    Ok(true)
+}
+
+/// Body of [`parse_fetch_response_raw`] (after the status word).
+pub fn parse_sql_response_raw(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    out: &mut Vec<RawValue>,
+) -> Result<(), FbError> {
+    out.clear();
+
+    decode_row(resp, xsqlda, version, &mut RawSink { out })
+}
+
+/// Destination for the columns of one decoded row. The wire layout is decoded in
+/// exactly one place ([`decode_row`]); the sink decides what a column becomes --
+/// a [`ParsedColumn`] (blobs deferred), a [`Column`] directly, or a zero-copy
+/// [`RawValue`].
+trait RowSink {
+    fn null(&mut self, var: &XSqlVar, sqltype: u32) -> Result<(), FbError>;
+
+    /// Text still in the connection charset, borrowed from the read buffer.
+    fn text(&mut self, var: &XSqlVar, sqltype: u32, data: Bytes) -> Result<(), FbError>;
+
+    fn integer(&mut self, var: &XSqlVar, sqltype: u32, value: i64) -> Result<(), FbError>;
+
+    fn floating(&mut self, var: &XSqlVar, sqltype: u32, value: f64) -> Result<(), FbError>;
+
+    fn timestamp(
+        &mut self,
+        var: &XSqlVar,
+        sqltype: u32,
+        ts: ibase::ISC_TIMESTAMP,
+    ) -> Result<(), FbError>;
+
+    fn boolean(&mut self, var: &XSqlVar, sqltype: u32, value: bool) -> Result<(), FbError>;
+
+    /// Only the blob id is on the wire; the data needs its own round-trips, so
+    /// sinks that cannot issue them reject the column.
+    fn blob(&mut self, var: &XSqlVar, sqltype: u32, id: BlobId) -> Result<(), FbError>;
+}
+
+/// Sink that collects [`ParsedColumn`], leaving blobs to be resolved later.
+struct ParsedColumnSink<'a> {
+    charset: &'a Charset,
+    out: &'a mut Vec<ParsedColumn>,
+}
+
+impl ParsedColumnSink<'_> {
+    fn push(&mut self, var: &XSqlVar, sqltype: u32, value: SqlType) {
+        self.out.push(ParsedColumn::Complete(Column::new(
+            var.alias_name.clone(),
+            sqltype,
+            value,
+        )));
+    }
+}
+
+impl RowSink for ParsedColumnSink<'_> {
+    fn null(&mut self, var: &XSqlVar, sqltype: u32) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Null);
+        Ok(())
+    }
+
+    fn text(&mut self, var: &XSqlVar, sqltype: u32, data: Bytes) -> Result<(), FbError> {
+        let text = self.charset.decode(&data[..])?;
+        self.push(var, sqltype, SqlType::Text(text));
+        Ok(())
+    }
+
+    fn integer(&mut self, var: &XSqlVar, sqltype: u32, value: i64) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Integer(value));
+        Ok(())
+    }
+
+    fn floating(&mut self, var: &XSqlVar, sqltype: u32, value: f64) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Floating(value));
+        Ok(())
+    }
+
+    fn timestamp(
+        &mut self,
+        var: &XSqlVar,
+        sqltype: u32,
+        ts: ibase::ISC_TIMESTAMP,
+    ) -> Result<(), FbError> {
+        self.push(
+            var,
+            sqltype,
+            SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
+        );
+        Ok(())
+    }
+
+    fn boolean(&mut self, var: &XSqlVar, sqltype: u32, value: bool) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Boolean(value));
+        Ok(())
+    }
+
+    fn blob(&mut self, var: &XSqlVar, _sqltype: u32, id: BlobId) -> Result<(), FbError> {
+        self.out.push(ParsedColumn::Blob {
+            binary: var.sqlsubtype == 0,
+            id,
+            col_name: var.alias_name.clone(),
+        });
+        Ok(())
+    }
+}
+
+/// Sink that builds [`Column`] directly, for statements with no blob columns.
+struct ColumnSink<'a> {
+    charset: &'a Charset,
+    out: &'a mut Vec<Column>,
+}
+
+impl ColumnSink<'_> {
+    fn push(&mut self, var: &XSqlVar, sqltype: u32, value: SqlType) {
+        self.out
+            .push(Column::new(var.alias_name.clone(), sqltype, value));
+    }
+}
+
+impl RowSink for ColumnSink<'_> {
+    fn null(&mut self, var: &XSqlVar, sqltype: u32) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Null);
+        Ok(())
+    }
+
+    fn text(&mut self, var: &XSqlVar, sqltype: u32, data: Bytes) -> Result<(), FbError> {
+        let text = self.charset.decode(&data[..])?;
+        self.push(var, sqltype, SqlType::Text(text));
+        Ok(())
+    }
+
+    fn integer(&mut self, var: &XSqlVar, sqltype: u32, value: i64) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Integer(value));
+        Ok(())
+    }
+
+    fn floating(&mut self, var: &XSqlVar, sqltype: u32, value: f64) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Floating(value));
+        Ok(())
+    }
+
+    fn timestamp(
+        &mut self,
+        var: &XSqlVar,
+        sqltype: u32,
+        ts: ibase::ISC_TIMESTAMP,
+    ) -> Result<(), FbError> {
+        self.push(
+            var,
+            sqltype,
+            SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
+        );
+        Ok(())
+    }
+
+    fn boolean(&mut self, var: &XSqlVar, sqltype: u32, value: bool) -> Result<(), FbError> {
+        self.push(var, sqltype, SqlType::Boolean(value));
+        Ok(())
+    }
+
+    fn blob(&mut self, _var: &XSqlVar, _sqltype: u32, _id: BlobId) -> Result<(), FbError> {
+        Err("parse_sql_response_columns called on a statement with blob columns".into())
+    }
+}
+
+/// Sink that emits [`RawValue`]: no charset decode, no allocation per column --
+/// text is a refcounted handle onto the read buffer.
+struct RawSink<'a> {
+    out: &'a mut Vec<RawValue>,
+}
+
+impl RowSink for RawSink<'_> {
+    fn null(&mut self, _var: &XSqlVar, _sqltype: u32) -> Result<(), FbError> {
+        self.out.push(RawValue::Null);
+        Ok(())
+    }
+
+    fn text(&mut self, _var: &XSqlVar, _sqltype: u32, data: Bytes) -> Result<(), FbError> {
+        self.out.push(RawValue::Text(data));
+        Ok(())
+    }
+
+    fn integer(&mut self, _var: &XSqlVar, _sqltype: u32, value: i64) -> Result<(), FbError> {
+        self.out.push(RawValue::Integer(value));
+        Ok(())
+    }
+
+    fn floating(&mut self, _var: &XSqlVar, _sqltype: u32, value: f64) -> Result<(), FbError> {
+        self.out.push(RawValue::Floating(value));
+        Ok(())
+    }
+
+    fn timestamp(
+        &mut self,
+        _var: &XSqlVar,
+        _sqltype: u32,
+        ts: ibase::ISC_TIMESTAMP,
+    ) -> Result<(), FbError> {
+        self.out.push(RawValue::Timestamp(
+            rsfbclient_core::date_time::decode_timestamp(ts),
+        ));
+        Ok(())
+    }
+
+    fn boolean(&mut self, _var: &XSqlVar, _sqltype: u32, value: bool) -> Result<(), FbError> {
+        self.out.push(RawValue::Boolean(value));
+        Ok(())
+    }
+
+    fn blob(&mut self, _var: &XSqlVar, _sqltype: u32, _id: BlobId) -> Result<(), FbError> {
+        Err("raw streaming called on a statement with blob columns".into())
+    }
+}
+
+/// Decodes the columns of one sql/fetch response body (after the op_code and,
+/// for a fetch, the status word) into `sink`. The wire format lives here once;
+/// the sink decides what each column becomes.
+fn decode_row<S: RowSink>(
+    resp: &mut Bytes,
+    xsqlda: &[XSqlVar],
+    version: ProtocolVersion,
+    sink: &mut S,
+) -> Result<(), FbError> {
     let has_row = resp.get_u32()? != 0;
     if !has_row {
         return Err("Fetch returned no columns".into());
@@ -847,11 +1088,7 @@ where
 
         if version >= ProtocolVersion::V13 && read_null(resp, col_index)? {
             // There is no data in protocol 13 if null, so just continue
-            sink(ParsedColumn::Complete(Column::new(
-                var.alias_name.clone(),
-                sqltype,
-                SqlType::Null,
-            )))?;
+            sink.null(var, sqltype)?;
             continue;
         }
 
@@ -859,57 +1096,30 @@ where
             ibase::SQL_VARYING => {
                 let d = resp.get_wire_bytes()?;
 
-                let null = read_null(resp, col_index)?;
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Text(charset.decode(&d[..])?),
-                    )))?
+                    sink.text(var, sqltype, d)?
                 }
             }
 
             ibase::SQL_INT64 => {
                 let i = resp.get_i64()?;
 
-                let null = read_null(resp, col_index)?;
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Integer(i),
-                    )))?
+                    sink.integer(var, sqltype, i)?
                 }
             }
 
             ibase::SQL_DOUBLE => {
                 let f = resp.get_f64()?;
 
-                let null = read_null(resp, col_index)?;
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Floating(f),
-                    )))?
+                    sink.floating(var, sqltype, f)?
                 }
             }
 
@@ -919,38 +1129,20 @@ where
                     timestamp_time: resp.get_u32()?,
                 };
 
-                let null = read_null(resp, col_index)?;
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Timestamp(rsfbclient_core::date_time::decode_timestamp(ts)),
-                    )))?
+                    sink.timestamp(var, sqltype, ts)?
                 }
             }
 
             ibase::SQL_BLOB if var.sqlsubtype <= 1 => {
                 let id = resp.get_u64()?;
 
-                let null = read_null(resp, col_index)?;
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Blob {
-                        binary: var.sqlsubtype == 0,
-                        id: BlobId(id),
-                        col_name: var.alias_name.clone(),
-                    })?
+                    sink.blob(var, sqltype, BlobId(id))?
                 }
             }
 
@@ -958,20 +1150,10 @@ where
                 let b = resp.get_u8()? == 1;
                 resp.advance(3)?; // Pad to 4 bytes
 
-                let null = read_null(resp, col_index)?;
-
-                if null {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Null,
-                    )))?
+                if read_null(resp, col_index)? {
+                    sink.null(var, sqltype)?
                 } else {
-                    sink(ParsedColumn::Complete(Column::new(
-                        var.alias_name.clone(),
-                        sqltype,
-                        SqlType::Boolean(b),
-                    )))?
+                    sink.boolean(var, sqltype, b)?
                 }
             }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -451,6 +451,38 @@ where
     }
 }
 
+/// Zero-copy row streaming, pure-rust backend only.
+#[cfg(feature = "pure_rust")]
+impl Connection<rsfbclient_rust::RustFbClient> {
+    /// Runs `sql` and hands each row to `visit` with no per-row allocation: the
+    /// row is decoded straight into a reusable `Vec<RawValue>`, where text
+    /// borrows the connection read buffer instead of being copied into a
+    /// `String`. Runs in the default transaction.
+    ///
+    /// The statement must have no blob columns (a blob needs its own round-trips,
+    /// which this path does not do); use [`Self::query_iter`] for those.
+    pub fn stream_raw<F>(&mut self, sql: &str, mut visit: F) -> Result<(), FbError>
+    where
+        F: FnMut(&[rsfbclient_rust::RawValue]) -> Result<(), FbError>,
+    {
+        use crate::statement::StatementData;
+
+        self.with_transaction(|tr| {
+            let mut stmt = StatementData::prepare(tr.conn, &mut tr.data, sql, false)?;
+
+            let result = (|| {
+                // Execute opens the select cursor; the rows are pulled by stream_raw.
+                stmt.query(tr.conn, &mut tr.data, ())?;
+                tr.conn.cli.stream_raw(&mut stmt.handle, &mut visit)
+            })();
+
+            stmt.close(tr.conn).ok();
+
+            result
+        })
+    }
+}
+
 #[cfg(test)]
 mk_tests_default! {
     use crate::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,10 @@ pub use rsfbclient_core::{
 #[doc(hidden)]
 pub use rsfbclient_core::{charset, Charset};
 
+/// Zero-copy row value for [`Connection::stream_raw`] (pure-rust backend only).
+#[cfg(feature = "pure_rust")]
+pub use rsfbclient_rust::{RawValue, RustFbClient};
+
 //builders are behind feature gates inside this module
 pub use crate::connection::builders;
 pub use builders::*;

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -459,3 +459,105 @@ mk_tests_default! {
         Ok(())
     }
 }
+
+/// The zero-copy streaming path only exists on the pure-rust backend, so it
+/// cannot be generated for every client like the tests above.
+#[cfg(feature = "pure_rust")]
+mod raw_stream {
+    use crate::{prelude::*, FbError, RawValue, Row, SqlType};
+
+    /// 250 rows (crossing the default fetch batch of 200) with one column of each
+    /// type the raw path supports, and every fifth row all null.
+    const ROWS: &str = "EXECUTE BLOCK RETURNS (n int, s varchar(20), d double precision,
+                                               b boolean, ts timestamp) AS
+                        DECLARE i int = 0;
+                        BEGIN
+                          WHILE (i < 250) DO BEGIN
+                            i = i + 1;
+                            IF (MOD(i, 5) = 0) THEN BEGIN
+                              n = NULL; s = NULL; d = NULL; b = NULL; ts = NULL;
+                            END ELSE BEGIN
+                              n = i;
+                              s = 'ação ' || i;
+                              d = CAST(i AS DOUBLE PRECISION) / 4;
+                              b = MOD(i, 2) = 0;
+                              ts = DATEADD(i SECOND TO TIMESTAMP '2020-01-01 12:00:00');
+                            END
+                            SUSPEND;
+                          END
+                        END";
+
+    fn render_column(col: &crate::Column) -> Result<String, FbError> {
+        Ok(match &col.value {
+            SqlType::Null => "null".to_string(),
+            SqlType::Text(t) => t.clone(),
+            SqlType::Integer(i) => i.to_string(),
+            SqlType::Floating(f) => f.to_string(),
+            SqlType::Boolean(b) => b.to_string(),
+            SqlType::Timestamp(ts) => ts.to_string(),
+            other => return Err(format!("unexpected column {:?}", other).into()),
+        })
+    }
+
+    fn render_raw(value: &RawValue) -> Result<String, FbError> {
+        Ok(match value {
+            RawValue::Null => "null".to_string(),
+            RawValue::Text(bytes) => std::str::from_utf8(bytes)
+                .map_err(|e| FbError::from(e.to_string()))?
+                .to_string(),
+            RawValue::Integer(i) => i.to_string(),
+            RawValue::Floating(f) => f.to_string(),
+            RawValue::Boolean(b) => b.to_string(),
+            RawValue::Timestamp(ts) => ts.to_string(),
+        })
+    }
+
+    #[test]
+    fn stream_raw_matches_the_column_api() -> Result<(), FbError> {
+        let mut conn = crate::builder_pure_rust().connect()?;
+
+        let mut expected: Vec<Vec<String>> = Vec::new();
+        for row in conn.query_iter::<(), Row>(ROWS, ())? {
+            expected.push(
+                row?.cols
+                    .iter()
+                    .map(render_column)
+                    .collect::<Result<_, FbError>>()?,
+            );
+        }
+
+        let mut streamed: Vec<Vec<String>> = Vec::new();
+        conn.stream_raw(ROWS, |row| {
+            streamed.push(row.iter().map(render_raw).collect::<Result<_, FbError>>()?);
+
+            Ok(())
+        })?;
+
+        assert_eq!(250, streamed.len());
+        assert_eq!(expected, streamed);
+
+        // The rows above only prove the two paths agree, so make sure they are not
+        // agreeing on nothing: every kind must have shown up.
+        assert_eq!(
+            vec!["1", "ação 1", "0.25", "false", "2020-01-01 12:00:01"],
+            streamed[0]
+        );
+        assert_eq!(vec!["null"; 5], streamed[4]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stream_raw_rejects_blob_columns() -> Result<(), FbError> {
+        let mut conn = crate::builder_pure_rust().connect()?;
+
+        let res = conn.stream_raw(
+            "select cast('abc' as blob sub_type 1) from rdb$database",
+            |_| Ok(()),
+        );
+
+        assert!(res.is_err(), "a blob column must not be streamed raw");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
> Based on #185 — the first commit here is that PR. Review/merge it first; the diff to look at in this one is the second commit.

Adds a fetch path that decodes rows straight into a reusable `Vec<RawValue>` instead of allocating a `Vec<Column>` per row and a `String` per text column. `RawValue::Text` holds a `Bytes` handle onto the wire read buffer, so text is delivered with no copy and no `String`: the caller validates UTF-8 and uses it in place.

- `RawValue` (`rsfbclient-rust/src/raw.rs`), re-exported from the top crate under the `pure_rust` feature
- generalize the row decoder: the closure sink from #185 becomes a `RowSink` trait, so the wire layout stays in one place (`decode_row`) and the three representations — `ParsedColumn` (blobs deferred), `Column`, `RawValue` — are just sinks. No second copy of the column decoding
- `parse_fetch_response_raw` / `parse_sql_response_raw` on top of it, plus `parse_one_fetch_response_raw` sharing the existing `op_fetch_response` framing
- `FirebirdWireConnection::stream_raw` + `fetch_batch_raw` reuse the batch fetch socket handling (`read_with`, so a response split across TCP reads still works); each row is handed to the visitor before the next response is read, since it borrows the read buffer
- `RustFbClient::stream_raw`, `StmtHandleData::has_blob`, and a concrete `Connection<RustFbClient>::stream_raw` driving prepare/execute/stream in the default transaction

Blob-free statements only: a blob needs its own round-trips, which this path does not do, so it is rejected (`has_blob`). The `Column` API is unchanged.

```rust
let mut conn = rsfbclient::builder_pure_rust().connect()?;

conn.stream_raw("select id, name from big_table", |row| {
    if let RawValue::Text(name) = &row[1] {
        // &[u8] straight from the read buffer, no String allocated
    }
    Ok(())
})?;
```

### Numbers

Measured end to end on a 187k-row, ~58-text-column select: per-row driver CPU ~9.0us -> ~1.6us, whole process CPU ~2.2s -> ~1.5s.

### How it was tested

New tests, pure_rust only (the API only exists on that backend, so they can't go through `mk_tests_default!`): 250 rows with one column of each supported type and every fifth row all null, streamed raw, must equal the same query through the `Column` API — that covers all of `Null`/`Text`/`Integer`/`Floating`/`Boolean`/`Timestamp` on both parsers; and a blob column must be rejected. 250 rows also crosses the default fetch batch of 200.

Full suite green against `jacobalberty/firebird:v5` and `:v3` (86 pass, i.e. the 84 of master plus these two; the same 6 environment-dependent tests fail on master too). `cargo clippy --all-features --tests` produces exactly the same warning set as master.

