### PR TITLE
Fix statement handle leaks and automatic transaction lifetime

### DIFF
--- a/examples/isolation_levels.rs
+++ b/examples/isolation_levels.rs
@@ -12,14 +12,11 @@
 //!     that another transaction updated first fails immediately with
 //!     "update conflicts with concurrent update" instead of blocking.
 //!
-//! The example uses explicit `SimpleTransaction` objects instead of the
-//! connection's default transaction on purpose: the default transaction
-//! is started once with the configuration given at connect time, and
-//! `Connection::commit`/`rollback` are RETAINING operations — the same
-//! physical transaction (with its configuration and, under SNAPSHOT,
-//! its snapshot) lives for the whole life of the connection. Explicit
-//! transaction objects give each demonstration its own configuration
-//! and a real, consuming commit.
+//! The example uses explicit `SimpleTransaction` objects so each
+//! demonstration has an independent transaction lifetime and
+//! configuration. The connection's automatic transaction is scoped to
+//! a query or execute call, while an explicit transaction remains active
+//! until its consuming commit or rollback.
 //!
 //! The table is created by the example itself (idempotent); you only
 //! need an `examples.fdb` database.

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), FbError> {
         Ok(())
     })?;
 
-    // New default transaction, but with a diferent transaction conf too
+    // New explicit default transaction with a different transaction configuration
     conn.begin_transaction_config(transaction_builder().read_only().build())?;
 
     Ok(())

--- a/rsfbclient-native/src/connection.rs
+++ b/rsfbclient-native/src/connection.rs
@@ -106,6 +106,24 @@ impl DynLoad {
     }
 }
 
+impl<T: LinkageMarker> NativeFbClient<T> {
+    fn drop_statement_after_prepare_error(
+        &mut self,
+        handle: &mut NativeStmtHandle,
+        error: FbError,
+    ) -> FbError {
+        unsafe {
+            self.ibase.isc_dsql_free_statement()(
+                &mut self.status[0],
+                handle,
+                FreeStmtOp::Drop as u16,
+            );
+        }
+
+        error
+    }
+}
+
 impl<T: LinkageMarker> FirebirdClientDbOps for NativeFbClient<T> {
     type DbHandle = NativeDbHandle;
     type AttachmentConfig = NativeFbAttachmentConfig;
@@ -343,7 +361,8 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
                 &mut *xsqlda,
             ) != 0
             {
-                return Err(self.status.as_error(&self.ibase));
+                let error = self.status.as_error(&self.ibase);
+                return Err(self.drop_statement_after_prepare_error(&mut handle, error));
             }
 
             let row_count = xsqlda.sqld;
@@ -355,7 +374,8 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
                 if self.ibase.isc_dsql_describe()(&mut self.status[0], &mut handle, 1, &mut *xsqlda)
                     != 0
                 {
-                    return Err(self.status.as_error(&self.ibase));
+                    let error = self.status.as_error(&self.ibase);
+                    return Err(self.drop_statement_after_prepare_error(&mut handle, error));
                 }
             }
 
@@ -372,7 +392,8 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
                 &mut info_buf[0],
             ) != 0
             {
-                return Err(self.status.as_error(&self.ibase));
+                let error = self.status.as_error(&self.ibase);
+                return Err(self.drop_statement_after_prepare_error(&mut handle, error));
             }
 
             for &v in &info_buf[3..] {
@@ -384,8 +405,10 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
             }
         }
 
-        let stmt_type = StmtType::try_from(stmt_type as u8)
-            .map_err(|_| FbError::from(format!("Invalid statement type: {}", stmt_type)))?;
+        let stmt_type = StmtType::try_from(stmt_type as u8).map_err(|_| {
+            let error = FbError::from(format!("Invalid statement type: {}", stmt_type));
+            self.drop_statement_after_prepare_error(&mut handle, error)
+        })?;
 
         // Create the column buffers and set the xsqlda conercions
         let col_buffers = (0..xsqlda.sqld)
@@ -396,7 +419,8 @@ impl<T: LinkageMarker> FirebirdClientSqlOps for NativeFbClient<T> {
 
                 ColumnBuffer::from_xsqlvar(xcol)
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<_, _>>()
+            .map_err(|error| self.drop_statement_after_prepare_error(&mut handle, error))?;
 
         Ok((
             stmt_type,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -202,11 +202,16 @@ impl<C: FirebirdClient> Connection<C> {
         let res = closure(&mut tr);
 
         if !in_transaction {
-            if res.is_ok() {
-                tr.commit_retaining()?;
-            } else {
-                tr.rollback_retaining()?;
-            }
+            return match res {
+                Ok(value) => {
+                    tr.commit()?;
+                    Ok(value)
+                }
+                Err(error) => {
+                    tr.rollback()?;
+                    Err(error)
+                }
+            };
         }
 
         let tr = TransactionData::from_transaction(tr);
@@ -274,14 +279,22 @@ impl<C: FirebirdClient> Connection<C> {
     pub fn commit(&mut self) -> Result<(), FbError> {
         self.in_transaction = false;
 
-        self.use_transaction(self.def_confs_tr, |tr| tr.commit_retaining())
+        if let Some(tr) = self.def_tr.take() {
+            tr.into_transaction(self).commit()
+        } else {
+            Ok(())
+        }
     }
 
     /// Rollback the default transaction
     pub fn rollback(&mut self) -> Result<(), FbError> {
         self.in_transaction = false;
 
-        self.use_transaction(self.def_confs_tr, |tr| tr.rollback_retaining())
+        if let Some(tr) = self.def_tr.take() {
+            tr.into_transaction(self).rollback()
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -319,16 +332,15 @@ where
     C: FirebirdClient,
 {
     fn drop(&mut self) {
-        // Close the cursor
-        self.stmt_cache_data
-            .as_mut()
-            .unwrap()
-            .stmt
-            .close_cursor(self.conn)
-            .ok();
+        let mut stmt_cache_data = self.stmt_cache_data.take().unwrap();
 
-        // Send the statement back to the cache
-        StmtCache::insert_and_close(self.conn, self.stmt_cache_data.take().unwrap()).ok();
+        if stmt_cache_data.stmt.close_cursor(self.conn).is_ok() {
+            // Only cache statements whose cursor was closed successfully.
+            StmtCache::insert_and_close(self.conn, stmt_cache_data).ok();
+        } else {
+            // A statement with an uncertain cursor state must not be reused.
+            stmt_cache_data.stmt.close(self.conn).ok();
+        }
 
         if !self.conn.in_transaction {
             // Commit the transaction
@@ -372,7 +384,8 @@ where
         P: IntoParams,
         R: FromRow + 'static,
     {
-        let stmt_cache_data = self.use_transaction(self.def_confs_tr, |tr| {
+        let in_transaction = self.in_transaction;
+        let stmt_cache_data = match self.use_transaction(self.def_confs_tr, |tr| {
             let params = params.to_params();
 
             // Get a statement from the cache
@@ -381,17 +394,21 @@ where
             match stmt_cache_data.stmt.query(tr.conn, &mut tr.data, params) {
                 Ok(_) => Ok(stmt_cache_data),
                 Err(e) => {
-                    // Return the statement to the cache
-                    StmtCache::insert_and_close(tr.conn, stmt_cache_data)?;
-
-                    if !tr.conn.in_transaction {
-                        tr.rollback_retaining().ok();
-                    }
+                    // A statement that failed to open its cursor must not be reused.
+                    stmt_cache_data.stmt.close(tr.conn).ok();
 
                     Err(e)
                 }
             }
-        })?;
+        }) {
+            Ok(stmt_cache_data) => stmt_cache_data,
+            Err(error) => {
+                if !in_transaction {
+                    self.rollback().ok();
+                }
+                return Err(error);
+            }
+        };
 
         let iter = StmtIter {
             stmt_cache_data: Some(stmt_cache_data),
@@ -420,10 +437,16 @@ where
             // Do not return now in case of error, because we need to return the statement to the cache
             let res = stmt_cache_data.stmt.execute(tr.conn, &mut tr.data, params);
 
-            // Return the statement to the cache
-            StmtCache::insert_and_close(tr.conn, stmt_cache_data)?;
-
-            res
+            match res {
+                Ok(value) => {
+                    StmtCache::insert_and_close(tr.conn, stmt_cache_data)?;
+                    Ok(value)
+                }
+                Err(error) => {
+                    stmt_cache_data.stmt.close(tr.conn).ok();
+                    Err(error)
+                }
+            }
         })
     }
 
@@ -441,12 +464,16 @@ where
             // Do not return now in case of error, because we need to return the statement to the cache
             let res = stmt_cache_data.stmt.execute2(tr.conn, &mut tr.data, params);
 
-            // Return the statement to the cache
-            StmtCache::insert_and_close(tr.conn, stmt_cache_data)?;
-
-            let f_res = FromRow::try_from(res?)?;
-
-            Ok(f_res)
+            match res {
+                Ok(row) => {
+                    StmtCache::insert_and_close(tr.conn, stmt_cache_data)?;
+                    FromRow::try_from(row)
+                }
+                Err(error) => {
+                    stmt_cache_data.stmt.close(tr.conn).ok();
+                    Err(error)
+                }
+            }
         })
     }
 }

--- a/src/connection/stmt_cache.rs
+++ b/src/connection/stmt_cache.rs
@@ -46,6 +46,10 @@ impl<T> StmtCache<T> {
     /// Adds a prepared statement to the cache, returning the previous one for this sql
     /// or another if the cache is full
     fn insert(&mut self, data: StmtCacheData<T>) -> Option<T> {
+        if self.cache.capacity() == 0 {
+            return Some(data.stmt);
+        }
+
         if self.sqls.contains(&data.sql) {
             // Insert the new one and return the old
             self.cache.insert(data.sql, data.stmt)
@@ -102,8 +106,6 @@ where
         conn: &mut Connection<C>,
         data: StmtCacheData<StatementData<C>>,
     ) -> Result<(), FbError> {
-        conn.stmt_cache.sqls.insert(data.sql.clone());
-
         // Insert the new one and close the old if exists
         if let Some(mut stmt) = conn.stmt_cache.insert(data) {
             stmt.close(conn)?;
@@ -166,6 +168,48 @@ fn stmt_cache_test() {
     assert_eq!(cache.get("sql 5").expect("sql5 not in the cache").stmt, 5);
     assert_eq!(cache.get("sql 6").expect("sql6 not in the cache").stmt, 6);
 
+    assert!(cache.cache.is_empty());
+    assert!(cache.sqls.is_empty());
+}
+
+#[test]
+fn stmt_cache_zero_capacity_returns_every_statement() {
+    let mut cache = StmtCache::new(0);
+
+    let stmt = cache
+        .insert(StmtCacheData {
+            sql: "select 1".to_string(),
+            stmt: 1,
+        })
+        .expect("zero-capacity cache must return the statement");
+
+    assert_eq!(stmt, 1);
+    assert!(cache.cache.is_empty());
+    assert!(cache.sqls.is_empty());
+}
+
+#[test]
+fn stmt_cache_replacement_returns_previous_statement() {
+    let mut cache = StmtCache::new(2);
+
+    assert!(cache
+        .insert(StmtCacheData {
+            sql: "select 1".to_string(),
+            stmt: 1,
+        })
+        .is_none());
+
+    let stmt = cache
+        .insert(StmtCacheData {
+            sql: "select 1".to_string(),
+            stmt: 2,
+        })
+        .expect("replaced statement must be returned");
+
+    assert_eq!(stmt, 1);
+    assert_eq!(cache.cache.len(), 1);
+    assert_eq!(cache.sqls.len(), 1);
+    assert_eq!(cache.get("select 1").unwrap().stmt, 2);
     assert!(cache.cache.is_empty());
     assert!(cache.sqls.is_empty());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,23 +89,16 @@
 //! features.
 //! # Transactions
 //!
-//! Every [Connection](./struct.Connection.html) keeps one **default transaction**, started
-//! lazily by the first `query`/`execute` call with the configuration given at connect time
-//! (the builder's `transaction(...)`/`with_transaction(...)` options; the defaults are
-//! `ReadCommited` + record version, `Wait` without timeout, read-write). Outside of an
-//! explicit `begin_transaction`, every statement is committed automatically.
+//! Every [Connection](./struct.Connection.html) starts a **default transaction** lazily for
+//! `query`/`execute` calls, using the configuration given at connect time (the builder's
+//! `transaction(...)`/`with_transaction(...)` options; the defaults are `ReadCommited` + record
+//! version, `Wait` without timeout, read-write). Outside of an explicit `begin_transaction`, the
+//! transaction is committed and released automatically after the statement completes. For a query
+//! iterator, this happens when the iterator is dropped after its cursor has been closed.
 //!
-//! Two properties of the default transaction are worth knowing:
-//!
-//! - [Connection::commit](./struct.Connection.html#method.commit) and
-//!   [Connection::rollback](./struct.Connection.html#method.rollback) are **retaining**
-//!   operations: they end the current unit of work but keep the same physical transaction
-//!   alive. Its configuration — and, for `TrIsolationLevel::Concurrency` (SNAPSHOT), the
-//!   snapshot it started with — persists for the whole life of the connection.
-//! - Because the physical transaction is reused,
-//!   [begin_transaction_config](./struct.Connection.html#method.begin_transaction_config)
-//!   only applies its configuration if the default transaction has not started yet (i.e.
-//!   before the first statement on the connection).
+//! [Connection::commit](./struct.Connection.html#method.commit) and
+//! [Connection::rollback](./struct.Connection.html#method.rollback) release the explicit default
+//! transaction started by `begin_transaction`/`begin_transaction_config`.
 //!
 //! When you need a transaction with its own isolation level, lock policy or lifetime —
 //! e.g. a SNAPSHOT reader beside a NO WAIT writer — create an explicit transaction object:

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -286,6 +286,38 @@ mk_tests_default! {
     }
 
     #[test]
+    #[cfg(all(feature = "native_client", not(feature = "pure_rust")))]
+    fn unsupported_column_drops_prepared_statement_handle() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        if conn.server_engine()? < EngineVersion::V4 {
+            return Ok(());
+        }
+
+        conn.execute("set bind of decfloat to native", ())?;
+
+        for attempt in 0..1_100 {
+            let result: Result<Option<(f64,)>, FbError> = conn.query_first(
+                "select cast(1 as decfloat(34)) from rdb$database",
+                (),
+            );
+            let error = result.expect_err("DECFLOAT(34) result must remain unsupported");
+            let message = error.to_string();
+            assert!(
+                message.contains("Unsupported column type (32762"),
+                "unexpected error at attempt {attempt}: {message}"
+            );
+        }
+
+        let (value,): (i64,) = conn
+            .query_first("select 1 from rdb$database", ())?
+            .expect("query after prepare errors must return one row");
+        assert_eq!(value, 1);
+
+        Ok(())
+    }
+
+    #[test]
     #[allow(clippy::float_cmp, clippy::excessive_precision)]
     fn fixed_points() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;

--- a/src/tests/transaction.rs
+++ b/src/tests/transaction.rs
@@ -37,6 +37,43 @@ mk_tests_default! {
     }
 
     #[test]
+    fn automatic_queries_release_their_transactions() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        let (first_transaction,): (i64,) = conn
+            .query_first("select current_transaction from rdb$database", ())?
+            .unwrap();
+        let (second_transaction,): (i64,) = conn
+            .query_first("select current_transaction from rdb$database", ())?
+            .unwrap();
+
+        assert_ne!(first_transaction, second_transaction);
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_connection_transaction_is_reused_until_commit() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+        conn.begin_transaction()?;
+
+        let (first_transaction,): (i64,) = conn
+            .query_first("select current_transaction from rdb$database", ())?
+            .unwrap();
+        let (second_transaction,): (i64,) = conn
+            .query_first("select current_transaction from rdb$database", ())?
+            .unwrap();
+
+        assert_eq!(first_transaction, second_transaction);
+        conn.commit()?;
+
+        let (next_transaction,): (i64,) = conn
+            .query_first("select current_transaction from rdb$database", ())?
+            .unwrap();
+        assert_ne!(first_transaction, next_transaction);
+        Ok(())
+    }
+
+    #[test]
     fn recreate_insert_drop_with_commit() -> Result<(), FbError> {
         const TABLE_NAME: &str = "RSFBCLIENT_TEST_TRANS0";
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -111,16 +111,15 @@ where
     C: FirebirdClient,
 {
     fn drop(&mut self) {
-        // Close the cursor
-        self.stmt_cache_data
-            .as_mut()
-            .unwrap()
-            .stmt
-            .close_cursor(self.tr.conn)
-            .ok();
+        let mut stmt_cache_data = self.stmt_cache_data.take().unwrap();
 
-        // Send the statement back to the cache
-        StmtCache::insert_and_close(self.tr.conn, self.stmt_cache_data.take().unwrap()).ok();
+        if stmt_cache_data.stmt.close_cursor(self.tr.conn).is_ok() {
+            // Only cache statements whose cursor was closed successfully.
+            StmtCache::insert_and_close(self.tr.conn, stmt_cache_data).ok();
+        } else {
+            // A statement with an uncertain cursor state must not be reused.
+            stmt_cache_data.stmt.close(self.tr.conn).ok();
+        }
     }
 }
 
@@ -171,8 +170,8 @@ impl<'c, C: FirebirdClient> Queryable for Transaction<'c, C> {
                 Ok(Box::new(iter))
             }
             Err(e) => {
-                // Return the statement to the cache
-                StmtCache::insert_and_close(self.conn, stmt_cache_data)?;
+                // A statement that failed to open its cursor must not be reused.
+                stmt_cache_data.stmt.close(self.conn).ok();
 
                 Err(e)
             }
@@ -195,10 +194,16 @@ impl<C: FirebirdClient> Execute for Transaction<'_, C> {
             .stmt
             .execute(self.conn, &mut self.data, params);
 
-        // Return the statement to the cache
-        StmtCache::insert_and_close(self.conn, stmt_cache_data)?;
-
-        res
+        match res {
+            Ok(value) => {
+                StmtCache::insert_and_close(self.conn, stmt_cache_data)?;
+                Ok(value)
+            }
+            Err(error) => {
+                stmt_cache_data.stmt.close(self.conn).ok();
+                Err(error)
+            }
+        }
     }
 
     fn execute_returnable<P, R>(&mut self, sql: &str, params: P) -> Result<R, FbError>
@@ -216,10 +221,16 @@ impl<C: FirebirdClient> Execute for Transaction<'_, C> {
             .stmt
             .execute2(self.conn, &mut self.data, params);
 
-        // Return the statement to the cache
-        StmtCache::insert_and_close(self.conn, stmt_cache_data)?;
-
-        FromRow::try_from(res?)
+        match res {
+            Ok(row) => {
+                StmtCache::insert_and_close(self.conn, stmt_cache_data)?;
+                FromRow::try_from(row)
+            }
+            Err(error) => {
+                stmt_cache_data.stmt.close(self.conn).ok();
+                Err(error)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- close statements on cache eviction and failed query/execute
- drop native statement handles when prepare, describe, metadata, or buffer setup fails
- release automatic transactions instead of retaining them

## Tests
- statement-cache unit tests
- Firebird 5: 1,100 unsupported-column errors followed by a successful query
- format, workspace compile, and clippy