### PR TITLE
Support Firebird INT128 values

### DIFF
--- a/examples/type_mapping.rs
+++ b/examples/type_mapping.rs
@@ -3,20 +3,17 @@
 //!
 //! Example of how Firebird data types map to Rust types
 //!
-//! The driver's `SqlType` is deliberately coarse: every integer arrives
-//! as i64, every float / NUMERIC / DECIMAL as f64, CHAR/VARCHAR as
-//! String, BLOB as Vec<u8> or String, TIMESTAMP as chrono types and
-//! BOOLEAN as bool. This example shows each mapping live, plus the two
+//! The driver's `SqlType` maps SMALLINT/INTEGER/BIGINT to i64, Firebird 4+
+//! INT128 to i128, every float / NUMERIC / DECIMAL to f64, CHAR/VARCHAR
+//! to String, BLOB to Vec<u8> or String, TIMESTAMP to chrono types and
+//! BOOLEAN to bool. This example shows each mapping live, plus the two
 //! sharp edges worth knowing:
 //!
 //!  - NUMERIC/DECIMAL are converted through f64, so scaled values whose
 //!    integer form exceeds 2^53 silently lose precision (shown below
 //!    with a value that comes back one cent off).
-//!  - Firebird 4+ types (INT128, DECFLOAT, TIMESTAMP/TIME WITH TIME
-//!    ZONE) and blobs with sub_type > 1 are not supported by the row
-//!    reader: selecting such a column fails at describe time with
-//!    "Unsupported column type". CAST them to VARCHAR (or BIGINT etc.)
-//!    in SQL to move the conversion server-side.
+//!  - Some Firebird 4+ types (DECFLOAT and TIMESTAMP/TIME WITH TIME ZONE)
+//!    and blobs with sub_type > 1 are not supported by the row reader.
 //!
 //! The table is created by the example itself (idempotent); you only
 //! need an `examples.fdb` database. The FB4-specific columns are added
@@ -30,7 +27,7 @@ use rsfbclient::{prelude::*, FbError, SimpleConnection};
 
 fn connect() -> Result<SimpleConnection, FbError> {
     #[cfg(feature = "linking")]
-    let conn = rsfbclient::builder_native()
+    let conn: SimpleConnection = rsfbclient::builder_native()
         .with_dyn_link()
         .with_remote()
         .host("localhost")
@@ -41,7 +38,7 @@ fn connect() -> Result<SimpleConnection, FbError> {
         .into();
 
     #[cfg(feature = "dynamic_loading")]
-    let conn = rsfbclient::builder_native()
+    let conn: SimpleConnection = rsfbclient::builder_native()
         .with_dyn_load("./fbclient.lib")
         .with_remote()
         .host("localhost")
@@ -52,7 +49,7 @@ fn connect() -> Result<SimpleConnection, FbError> {
         .into();
 
     #[cfg(feature = "pure_rust")]
-    let conn = rsfbclient::builder_pure_rust()
+    let conn: SimpleConnection = rsfbclient::builder_pure_rust()
         .host("localhost")
         .db_name("examples.fdb")
         .user("SYSDBA")
@@ -128,21 +125,23 @@ fn main() -> Result<(), FbError> {
         .unwrap();
     println!("numeric via CAST    : {}   <- exact", num_text);
 
-    // 2. The unsupported types fail at describe time...
+    // 2. A real INT128 remains exact and is returned as Rust i128.
     if fb4 {
-        match conn.query_first::<(), (String,)>("select c_i128 from type_probe", ()) {
-            Ok(_) => println!("unexpected: INT128 fetched"),
-            Err(e) => println!("select c_i128 fails  : {}", e),
-        }
-        // ...and CAST moves the conversion server-side
-        let (i128_text, dec_text): (String, String) = conn
-            .query_first(
-                "select cast(c_i128 as varchar(50)), cast(c_dec as varchar(50)) from type_probe",
-                (),
-            )?
+        let (int128,): (i128,) = conn
+            .query_first("select c_i128 from type_probe", ())?
             .unwrap();
-        println!("int128 via CAST     : {}", i128_text);
-        println!("decfloat via CAST   : {}", dec_text);
+        println!("int128   -> i128   : {}", int128);
+
+        // DECFLOAT remains unsupported. Text conversion is shown only to
+        // demonstrate its exact digits, not as an INT128 compatibility path.
+        match conn.query_first::<(), (String,)>("select c_dec from type_probe", ()) {
+            Ok(_) => println!("unexpected: DECFLOAT fetched"),
+            Err(e) => println!("select c_dec fails   : {}", e),
+        }
+        let (dec_text,): (String,) = conn
+            .query_first("select cast(c_dec as varchar(50)) from type_probe", ())?
+            .unwrap();
+        println!("decfloat as text    : {}", dec_text);
     } else {
         println!("(Firebird 3 server: INT128/DECFLOAT part skipped)");
     }

--- a/rsfbclient-core/src/ibase.rs
+++ b/rsfbclient-core/src/ibase.rs
@@ -304,6 +304,7 @@ pub const SQL_QUAD: u32 = 550;
 pub const SQL_TYPE_TIME: u32 = 560;
 pub const SQL_TYPE_DATE: u32 = 570;
 pub const SQL_INT64: u32 = 580;
+pub const SQL_INT128: u32 = 32752;
 pub const SQL_BOOLEAN: u32 = 32764;
 pub const SQL_NULL: u32 = 32766;
 pub const SQL_DATE: u32 = 510;

--- a/rsfbclient-core/src/lib.rs
+++ b/rsfbclient-core/src/lib.rs
@@ -24,6 +24,9 @@ pub enum SqlType {
 
     Integer(i64),
 
+    /// Firebird 4+ `INT128` value.
+    Int128(i128),
+
     Floating(f64),
 
     Timestamp(chrono::NaiveDateTime),

--- a/rsfbclient-core/src/params.rs
+++ b/rsfbclient-core/src/params.rs
@@ -21,6 +21,7 @@ impl SqlType {
                 }
             }
             Integer(_) => (ibase::SQL_INT64 + 1, 0),
+            Int128(_) => (ibase::SQL_INT128 + 1, 0),
             Floating(_) => (ibase::SQL_DOUBLE + 1, 0),
             Timestamp(_) => (ibase::SQL_TIMESTAMP + 1, 0),
             Null => (ibase::SQL_TEXT + 1, 0),
@@ -50,6 +51,12 @@ impl IntoParam for String {
 impl IntoParam for i64 {
     fn into_param(self) -> SqlType {
         Integer(self)
+    }
+}
+
+impl IntoParam for i128 {
+    fn into_param(self) -> SqlType {
+        Int128(self)
     }
 }
 

--- a/rsfbclient-core/src/row.rs
+++ b/rsfbclient-core/src/row.rs
@@ -66,6 +66,8 @@ impl ColumnToVal<String> for Column {
 
             Integer(i) => Ok(i.to_string()),
 
+            Int128(i) => Ok(i.to_string()),
+
             Floating(f) => Ok(f.to_string()),
 
             Timestamp(ts) => Ok(ts.to_string()),
@@ -75,6 +77,20 @@ impl ColumnToVal<String> for Column {
             Boolean(bo) => Ok(bo.to_string()),
 
             Null => Err(err_column_null("String")),
+        }
+    }
+}
+
+impl ColumnToVal<i128> for Column {
+    fn to_val(self) -> Result<i128, FbError> {
+        match self.value {
+            Integer(i) => Ok(i128::from(i)),
+
+            Int128(i) => Ok(i),
+
+            Null => Err(err_column_null("i128")),
+
+            col => err_type_conv(col, "i128"),
         }
     }
 }

--- a/rsfbclient-native/src/params.rs
+++ b/rsfbclient-native/src/params.rs
@@ -120,6 +120,8 @@ enum ParamBufferData {
 
     Integer(Box<i64>),
 
+    Int128(Box<i128>),
+
     Floating(Box<f64>),
 
     Timestamp(Box<ibase::ISC_TIMESTAMP>),
@@ -138,6 +140,7 @@ impl ParamBufferData {
         match self {
             Text(s) => s.as_ptr() as _,
             Integer(i) => &**i as *const _ as _,
+            Int128(i) => i.as_mut() as *mut i128 as _,
             Floating(f) => &**f as *const _ as _,
             Timestamp(ts) => &**ts as *const _ as _,
             Null => ptr::null_mut(),
@@ -178,6 +181,8 @@ impl ParamBuffer {
             }
 
             SqlType::Integer(i) => (mem::size_of_val(&i), Integer(Box::new(i))),
+
+            SqlType::Int128(i) => (mem::size_of_val(&i), Int128(Box::new(i))),
 
             SqlType::Floating(f) => (mem::size_of_val(&f), Floating(Box::new(f))),
 

--- a/rsfbclient-native/src/row.rs
+++ b/rsfbclient-native/src/row.rs
@@ -18,6 +18,8 @@ pub enum ColumnBufferData {
     Text(Varchar),
     /// Coerces to Int64
     Integer(Box<i64>),
+    /// Native Firebird INT128
+    Int128(Box<i128>),
     /// Coerces to Double
     Float(Box<f64>),
     /// Coerces to Timestamp
@@ -35,6 +37,7 @@ impl ColumnBufferData {
         match self {
             Text(v) => v.as_ptr() as _,
             Integer(i) => &**i as *const _ as _,
+            Int128(i) => i.as_mut() as *mut i128 as _,
             Float(f) => &**f as *const _ as _,
             Timestamp(ts) => &**ts as *const _ as _,
             BlobText(bid) => &**bid as *const _ as _,
@@ -99,6 +102,23 @@ impl ColumnBuffer {
                 var.sqltype = ibase::SQL_VARYING as i16 + 1;
 
                 Text(Varchar::new(var.sqllen as u16))
+            }
+
+            ibase::SQL_INT128 if sqlsubtype == 0 && var.sqlscale == 0 => {
+                var.sqllen = mem::size_of::<i128>() as i16;
+                var.sqltype = ibase::SQL_INT128 as i16 + 1;
+
+                Int128(Box::new(0))
+            }
+
+            ibase::SQL_INT128 => {
+                // NUMERIC/DECIMAL backed by INT128 follows the crate's existing
+                // fixed-point policy and is converted to double by fbclient.
+                var.sqllen = mem::size_of::<f64>() as i16;
+                var.sqlscale = 0;
+                var.sqltype = ibase::SQL_DOUBLE as i16 + 1;
+
+                Float(Box::new(0.0))
             }
 
             ibase::SQL_SHORT | ibase::SQL_LONG | ibase::SQL_INT64 => {
@@ -180,6 +200,8 @@ impl ColumnBuffer {
             Text(varchar) => SqlType::Text(charset.decode(varchar.as_bytes())?),
 
             Integer(i) => SqlType::Integer(**i),
+
+            Int128(i) => SqlType::Int128(**i),
 
             Float(f) => SqlType::Floating(**f),
 

--- a/rsfbclient-rust/src/blr.rs
+++ b/rsfbclient-rust/src/blr.rs
@@ -86,6 +86,16 @@ pub fn params_to_blr(
                 values.put_i64(*i);
             }
 
+            SqlType::Int128(i) => {
+                blr.put_slice(&[
+                    consts::blr::INT128,
+                    0, // Scale
+                ]);
+
+                values.put_i64((i >> 64) as i64);
+                values.put_u64(*i as u64);
+            }
+
             SqlType::Floating(f) => {
                 blr.put_u8(consts::blr::DOUBLE);
 

--- a/rsfbclient-rust/src/consts.rs
+++ b/rsfbclient-rust/src/consts.rs
@@ -1673,6 +1673,7 @@ pub mod blr {
     pub const COLUMN_NAME: u8 = 21;
     pub const COLUMN_NAME2: u8 = 22;
     pub const BOOL: u8 = 23;
+    pub const INT128: u8 = 26;
     // first sub parameter for domain_name[2]
     pub const DOMAIN_TYPE_OF: u8 = 0;
     pub const DOMAIN_FULL: u8 = 1;

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -831,6 +831,27 @@ pub fn parse_sql_response(
                 }
             }
 
+            ibase::SQL_INT128 => {
+                let high = resp.get_i64()?;
+                let low = resp.get_u64()?;
+                let i = (i128::from(high) << 64) | i128::from(low);
+
+                let null = read_null(resp, col_index)?;
+                if null {
+                    data.push(ParsedColumn::Complete(Column::new(
+                        var.alias_name.clone(),
+                        sqltype,
+                        SqlType::Null,
+                    )))
+                } else {
+                    data.push(ParsedColumn::Complete(Column::new(
+                        var.alias_name.clone(),
+                        sqltype,
+                        SqlType::Int128(i),
+                    )))
+                }
+            }
+
             ibase::SQL_DOUBLE => {
                 let f = resp.get_f64()?;
 
@@ -1234,4 +1255,43 @@ pub fn parse_info_sql_affected_rows(data: &mut Bytes) -> Result<usize, FbError> 
     }
 
     Ok(affected_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsfbclient_core::charset::UTF_8;
+
+    fn assert_int128_decoded(expected: i128) {
+        let mut response = BytesMut::new();
+        response.put_u32(1); // Row is present.
+        response.put_u32(0); // Protocol 13 null bitmap, aligned to four bytes.
+        response.put_i64((expected >> 64) as i64);
+        response.put_u64(expected as u64);
+
+        let xsqlda = [XSqlVar {
+            sqltype: ibase::SQL_INT128 as i16 + 1,
+            data_length: 16,
+            alias_name: "VALUE".to_owned(),
+            ..Default::default()
+        }];
+
+        let mut response = response.freeze();
+        let columns =
+            parse_sql_response(&mut response, &xsqlda, ProtocolVersion::V13, &UTF_8).unwrap();
+
+        match &columns[0] {
+            ParsedColumn::Complete(column) => match &column.value {
+                SqlType::Int128(actual) => assert_eq!(*actual, expected),
+                actual => panic!("expected INT128, got {actual:?}"),
+            },
+            ParsedColumn::Blob { .. } => panic!("expected INT128, got blob"),
+        }
+    }
+
+    #[test]
+    fn int128_wire_value_keeps_all_bits() {
+        assert_int128_decoded(123456789012345678901234567890_i128);
+        assert_int128_decoded(-123456789012345678901234567890_i128);
+    }
 }

--- a/rsfbclient-rust/src/xsqlda.rs
+++ b/rsfbclient-rust/src/xsqlda.rs
@@ -72,6 +72,19 @@ impl XSqlVar {
                 self.sqltype = ibase::SQL_VARYING as i16 + 1;
             }
 
+            ibase::SQL_INT128 if sqlsubtype == 0 && self.scale == 0 => {
+                self.data_length = mem::size_of::<i128>() as i16;
+                self.sqltype = ibase::SQL_INT128 as i16 + 1;
+            }
+
+            ibase::SQL_INT128 => {
+                // NUMERIC/DECIMAL backed by INT128 follows the crate's existing
+                // fixed-point policy and is converted to double by Firebird.
+                self.data_length = mem::size_of::<f64>() as i16;
+                self.scale = 0;
+                self.sqltype = ibase::SQL_DOUBLE as i16 + 1;
+            }
+
             ibase::SQL_SHORT | ibase::SQL_LONG | ibase::SQL_INT64 => {
                 self.data_length = mem::size_of::<i64>() as i16;
 
@@ -139,6 +152,8 @@ pub fn xsqlda_to_blr(xsqlda: &[XSqlVar]) -> Result<Bytes, FbError> {
                 consts::blr::INT64,
                 0, // Scale
             ]),
+
+            ibase::SQL_INT128 => blr.put_slice(&[consts::blr::INT128, var.scale as u8]),
 
             ibase::SQL_DOUBLE => blr.put_u8(consts::blr::DOUBLE),
 
@@ -402,4 +417,49 @@ fn err_invalid_xsqlda<T>() -> Result<T, FbError> {
     Err(FbError::Other(
         "Invalid Xsqlda received from server".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_point_int128_is_requested_as_double() {
+        let mut var = XSqlVar {
+            sqltype: ibase::SQL_INT128 as i16 + 1,
+            scale: -4,
+            sqlsubtype: 2,
+            data_length: 16,
+            ..Default::default()
+        };
+
+        var.coerce().unwrap();
+
+        assert_eq!(var.sqltype, ibase::SQL_DOUBLE as i16 + 1);
+        assert_eq!(var.scale, 0);
+        assert_eq!(var.data_length, mem::size_of::<f64>() as i16);
+
+        let blr = xsqlda_to_blr(&[var]).unwrap();
+        assert_eq!(blr[6], consts::blr::DOUBLE);
+    }
+
+    #[test]
+    fn integer_int128_is_preserved() {
+        let mut var = XSqlVar {
+            sqltype: ibase::SQL_INT128 as i16 + 1,
+            scale: 0,
+            sqlsubtype: 0,
+            data_length: 16,
+            ..Default::default()
+        };
+
+        var.coerce().unwrap();
+
+        assert_eq!(var.sqltype, ibase::SQL_INT128 as i16 + 1);
+        assert_eq!(var.scale, 0);
+        assert_eq!(var.data_length, mem::size_of::<i128>() as i16);
+
+        let blr = xsqlda_to_blr(&[var]).unwrap();
+        assert_eq!(&blr[6..8], &[consts::blr::INT128, 0]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@
 //! | Firebird type | Rust type |
 //! |---|---|
 //! | `SMALLINT`, `INTEGER`, `BIGINT` | `i64` (or any smaller integer type via `try_into`) |
+//! | `INT128` (Firebird 4+) | `i128` |
 //! | `FLOAT`, `DOUBLE PRECISION`, `NUMERIC`, `DECIMAL` | `f64` / `f32` |
 //! | `CHAR`, `VARCHAR` | `String` (decoded with the connection charset) |
 //! | `BLOB SUB_TYPE TEXT` | `String` |
@@ -149,11 +150,11 @@
 //!   2^53 lose precision silently (e.g. `NUMERIC(18,2)` storing `90071992547409.93` reads
 //!   back as `90071992547409.92`). When the exact digits matter, `CAST` the column to
 //!   `VARCHAR` in SQL and parse, or keep the value in a wider text/integer form.
-//! - **Firebird 4+ types are not supported by the row reader**: selecting an `INT128`,
+//! - **Some Firebird 4+ types are not supported by the row reader**: selecting a
 //!   `DECFLOAT(16/34)`, `TIMESTAMP WITH TIME ZONE` or `TIME WITH TIME ZONE` column (or a
 //!   blob with `sub_type > 1`) fails at describe time with *"Unsupported column type"*.
-//!   `CAST` such columns to `VARCHAR`/`BIGINT`/plain `TIMESTAMP` in the SQL to move the
-//!   conversion server-side.
+//!   Plain `INT128` is preserved as `i128`; `NUMERIC`/`DECIMAL` values backed by INT128
+//!   follow the same `f64` mapping as their lower-precision counterparts.
 //!
 //! See `examples/type_mapping.rs` for all of the above, live.
 //!

--- a/src/tests/row.rs
+++ b/src/tests/row.rs
@@ -322,6 +322,44 @@ mk_tests_default! {
 
     #[test]
     #[allow(clippy::float_cmp)]
+    #[cfg(all(feature = "native_client", not(feature = "pure_rust")))]
+    fn int128_and_decimal_28_mapping() -> Result<(), FbError> {
+        let mut conn = cbuilder().connect()?;
+
+        if conn.server_engine()? < EngineVersion::V4 {
+            return Ok(());
+        }
+
+        conn.execute("set bind of int128 to native", ())?;
+
+        let expected_int128 = 123456789012345678901234567890_i128;
+        let (positive, negative): (i128, i128) = conn
+            .query_first(
+                "select cast(123456789012345678901234567890 as int128), cast(-123456789012345678901234567890 as int128) from rdb$database",
+                (),
+            )?
+            .expect("INT128 query must return one row");
+        assert_eq!(positive, expected_int128);
+        assert_eq!(negative, -expected_int128);
+
+        let (parameter,): (i128,) = conn
+            .query_first("select cast(? as int128) from rdb$database", (expected_int128,))?
+            .expect("INT128 parameter query must return one row");
+        assert_eq!(parameter, expected_int128);
+
+        let (decimal_28, expected_decimal_28): (f64, f64) = conn
+            .query_first(
+                "select cast(1.2345 as decimal(28,4)), cast(cast(1.2345 as decimal(28,4)) as double precision) from rdb$database",
+                (),
+            )?
+            .expect("DECIMAL(28,4) query must return one row");
+        assert_eq!(decimal_28, expected_decimal_28);
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
     fn float_points() -> Result<(), FbError> {
         let mut conn = cbuilder().connect()?;
 


### PR DESCRIPTION
Adds Firebird 4+ INT128 support. Plain INT128 maps to Rust i128; INT128-backed NUMERIC/DECIMAL (including DECIMAL(28,4)) maps to f64. Includes native and pure-Rust tests.