### PR TITLE
Pure rust "connection rejected" regression fixed

### DIFF
--- a/rsfbclient-rust/src/client.rs
+++ b/rsfbclient-rust/src/client.rs
@@ -994,6 +994,12 @@ impl FirebirdWireConnection {
 
                 let parsed_cols = parse_sql_response(resp, xsqlda, version, &charset)?;
 
+                // The sql response is followed by its own op_response, framed with
+                // its own op_code just like every other response on the wire.
+                let op_code = next_op_code(resp)?;
+                if op_code != WireOp::Response as u32 {
+                    return err_conn_rejected(op_code);
+                }
                 parse_response(resp)?;
 
                 Ok(parsed_cols)

--- a/rsfbclient-rust/src/wire.rs
+++ b/rsfbclient-rust/src/wire.rs
@@ -1008,6 +1008,12 @@ pub fn parse_status_vector(resp: &mut Bytes) -> Result<(), FbError> {
                 }
             }
 
+            // New warning (e.g. from a DDL statement). Not surfaced as an error,
+            // just consume its code so the vector stays aligned.
+            ibase::isc_arg_warning => {
+                resp.get_u32()?;
+            }
+
             // Error message arg number
             ibase::isc_arg_number => {
                 let num = resp.get_i32()?;


### PR DESCRIPTION
76621aa(#179) made read_with() preserve unconsumed bytes across calls instead of silently dropping them. That surfaced two latent bugs that were previously harmless only because leftovers were discarded:
- execute2's closure called parse_response() right after parse_sql_response(), but the trailing op_response is framed with its own op_code like every other response on the wire. Skipping it left the response's own [op_code=9] sitting in pending, which the next read (e.g. commit_retaining) misread as the following operation's op_code, producing "Connection rejected with code 1 (Connect)".
- parse_status_vector() had no arm for isc_arg_warning (18). Any status vector containing a warning (e.g. from CREATE USER) hit the catch-all "Invalid / Unknown status vector item" error before consuming the warning's code word, leaving pending misaligned for every subsequent read and cascading into garbage op_codes during rollback/detach.